### PR TITLE
Expose core submodules via package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Matrix0 is an efficient, AlphaZero-style chess engine designed specifically for 
 ```
 Matrix0/
 ├── azchess/                    # Core package
-│   ├── __init__.py            # Package exports
+│   ├── __init__.py            # Exports config, data_manager, mcts, model
 │   ├── config.py              # Configuration management
 │   ├── model/                 # Neural network models
 │   │   ├── resnet.py         # ResNet with attention & SSL
@@ -69,6 +69,12 @@ Matrix0/
 │   └── backups/              # Data backups
 ├── logs/                      # Training logs
 └── webui/                     # Web interface (eval-only)
+```
+
+The package re-exports its most commonly used modules, allowing direct access:
+
+```python
+from azchess import config, data_manager, mcts, model
 ```
 
 ## 🚀 **Quick Start**

--- a/azchess/__init__.py
+++ b/azchess/__init__.py
@@ -1,3 +1,14 @@
-__all__ = [
-    "config",
-]
+"""Convenience imports for the :mod:`azchess` package.
+
+Importing :mod:`azchess` now exposes commonly used submodules directly::
+
+    from azchess import config, data_manager, mcts, model
+
+This mirrors the layout of the package and keeps ``from azchess import *``
+functional without creating circular imports.
+"""
+
+from . import config, data_manager, mcts, model
+
+__all__ = ["config", "data_manager", "mcts", "model"]
+

--- a/azchess/data_manager.py
+++ b/azchess/data_manager.py
@@ -62,63 +62,6 @@ class DataManager:
         # Version tracking
         self.version = "1.0.0"
         
-    from __future__ import annotations
-
-import os
-import json
-import hashlib
-import sqlite3
-from dataclasses import dataclass, asdict
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Iterator
-from datetime import datetime
-import numpy as np
-import logging
-import argparse
-import time
-
-logger = logging.getLogger(__name__)
-
-
-@dataclass
-class DataShard:
-    """Represents a single data shard with metadata."""
-    path: str
-    size_bytes: int
-    sample_count: int
-    created_at: str
-    checksum: str
-    version: str
-    corrupted: bool = False
-
-
-@dataclass
-class DataStats:
-    """Statistics about the data pipeline."""
-    total_shards: int
-    total_samples: int
-    total_size_gb: float
-    corrupted_shards: int
-    last_updated: str
-
-
-class DataManager:
-    """Manages the replay buffer and data pipeline for Matrix0 training."""
-    
-    def __init__(self, base_dir: str = "data", max_shards: int = 128, shard_size: int = 16384):
-        self.base_dir = Path(base_dir)
-        self.max_shards = max_shards
-        self.shard_size = shard_size
-        
-        # Ensure directories exist
-        self.selfplay_dir = self.base_dir / "selfplay"
-        self.replays_dir = self.base_dir / "replays"
-        self.validation_dir = self.base_dir / "validation"
-        self.backups_dir = self.base_dir / "backups"
-        
-        for dir_path in [self.selfplay_dir, self.replays_dir, self.validation_dir, self.backups_dir]:
-            dir_path.mkdir(parents=True, exist_ok=True)
-        
         # Initialize database for tracking
         self.db_path = self.base_dir / "data_metadata.db"
         self._init_database()


### PR DESCRIPTION
## Summary
- expose `config`, `data_manager`, `mcts`, and `model` at the `azchess` package level
- document exported modules in the README
- clean up duplicate `__future__` import in `data_manager` so the module can be imported

## Testing
- `python -c "import azchess; azchess.data_manager; print('ok')"`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4925fbb288323a80a0883caa14854