### PR TITLE
Refactor analyze_games with CLI and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ python -m azchess.cli_play
 uvicorn webui.server:app --host 127.0.0.1 --port 8000
 ```
 
+### **5. Analyze Self-Play Games**
+```bash
+python analyze_games.py --directory data/selfplay --date-pattern "2025-08-16T15:*"
+```
+
+- `--directory` &mdash; Location of self-play game files (default: `data/selfplay`)
+- `--date-pattern` &mdash; Glob fragment used to match game files, appended after
+  `selfplay_w*_g*_` (default: `2025-08-16T15:*`)
+
+When run without arguments the script behaves as before, analyzing games in
+`data/selfplay` that match the default pattern.
+
 ## ⚙️ **Configuration**
 
 The main configuration is in `config.yaml` with sections for:

--- a/analyze_games.py
+++ b/analyze_games.py
@@ -1,54 +1,96 @@
 #!/usr/bin/env python3
-import numpy as np
+"""Analyze self-play games."""
+
+import argparse
 import glob
-from datetime import datetime
+import logging
+import os
 
-# Find all games from today
-games = sorted(glob.glob('data/selfplay/selfplay_w*_g*_2025-08-16T15:*.npz'))
+import numpy as np
 
-print("=== SELF-PLAY ANALYSIS ===")
-print(f"Total games: {len(games)}")
 
-total_moves = 0
-results = []
-game_details = []
+def analyze_games(directory: str, date_pattern: str) -> None:
+    """Summarize self-play game statistics.
 
-for game_file in games:
-    try:
-        data = np.load(game_file)
-        moves = len(data['s'])
-        result = np.unique(data['z'])
-        total_moves += moves
-        
-        # Extract timestamp from filename
-        timestamp = game_file.split('_')[-1].replace('.npz', '')
-        game_details.append((timestamp, moves, result))
-        
-        results.extend(result)
-        
-    except Exception as e:
-        print(f"Error loading {game_file}: {e}")
+    Parameters
+    ----------
+    directory: str
+        Directory containing self-play game files.
+    date_pattern: str
+        Glob pattern representing the date/time portion of filenames.
+    """
+    games = sorted(
+        glob.glob(os.path.join(directory, f"selfplay_w*_g*_{date_pattern}.npz"))
+    )
 
-print(f"Total moves: {total_moves}")
-print(f"Average moves per game: {total_moves/len(games):.1f}")
+    logging.info("=== SELF-PLAY ANALYSIS ===")
+    logging.info("Total games: %s", len(games))
 
-# Analyze results
-unique_results, counts = np.unique(results, return_counts=True)
-print(f"Results: {dict(zip(unique_results, counts))}")
+    total_moves = 0
+    results = []
+    game_details = []
 
-# Calculate win rates
-white_wins = np.sum(np.array(results) > 0)
-black_wins = np.sum(np.array(results) < 0)
-draws = np.sum(np.array(results) == 0)
+    for game_file in games:
+        try:
+            data = np.load(game_file)
+            moves = len(data["s"])
+            result = np.unique(data["z"])
+            total_moves += moves
 
-print(f"White wins: {white_wins} ({white_wins/len(results):.1%})")
-print(f"Black wins: {black_wins} ({black_wins/len(results):.1%})")
-print(f"Draws: {draws} ({draws/len(results):.1%})")
+            # Extract timestamp from filename
+            timestamp = game_file.split("_")[-1].replace(".npz", "")
+            game_details.append((timestamp, moves, result))
 
-print("\n=== GAME DETAILS ===")
-for timestamp, moves, result in game_details:
-    print(f"{timestamp}: {moves} moves, result: {result}")
+            results.extend(result)
 
-# Check current config
-print("\n=== CURRENT CONFIG ===")
-print("Check config.yaml for actual simulation counts being used")
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.error("Error loading %s: %s", game_file, exc)
+
+    if not games:
+        logging.info("No games found.")
+        return
+
+    logging.info("Total moves: %s", total_moves)
+    logging.info("Average moves per game: %.1f", total_moves / len(games))
+
+    # Analyze results
+    unique_results, counts = np.unique(results, return_counts=True)
+    logging.info("Results: %s", dict(zip(unique_results, counts)))
+
+    # Calculate win rates
+    white_wins = np.sum(np.array(results) > 0)
+    black_wins = np.sum(np.array(results) < 0)
+    draws = np.sum(np.array(results) == 0)
+
+    logging.info("White wins: %s (%s)", white_wins, f"{white_wins/len(results):.1%}")
+    logging.info("Black wins: %s (%s)", black_wins, f"{black_wins/len(results):.1%}")
+    logging.info("Draws: %s (%s)", draws, f"{draws/len(results):.1%}")
+
+    logging.info("\n=== GAME DETAILS ===")
+    for timestamp, moves, result in game_details:
+        logging.info("%s: %s moves, result: %s", timestamp, moves, result)
+
+    logging.info("\n=== CURRENT CONFIG ===")
+    logging.info("Check config.yaml for actual simulation counts being used")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze self-play games")
+    parser.add_argument(
+        "--directory",
+        default="data/selfplay",
+        help="Directory containing self-play game files",
+    )
+    parser.add_argument(
+        "--date-pattern",
+        default="2025-08-16T15:*",
+        help="Date pattern to match in filenames (e.g., '2025-08-16T15:*')",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    analyze_games(args.directory, args.date_pattern)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add argparse-based `--directory` and `--date-pattern` options to `analyze_games.py`
- Replace print statements with logging and introduce a main entry point
- Document the script's CLI in the README

## Testing
- `pytest`
- `python analyze_games.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4925569588323b13583941539c517