### PR TITLE
Refactor DataManager to remove duplicate block

### DIFF
--- a/azchess/data_manager.py
+++ b/azchess/data_manager.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import os
 import json
 import hashlib
 import sqlite3
 from dataclasses import dataclass, asdict
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Iterator
+from typing import Dict, List, Tuple, Iterator
 from datetime import datetime
 import numpy as np
 import logging
@@ -40,92 +39,28 @@ class DataStats:
 
 class DataManager:
     """Manages the replay buffer and data pipeline for Matrix0 training."""
-    
+
     def __init__(self, base_dir: str = "data", max_shards: int = 128, shard_size: int = 16384):
         self.base_dir = Path(base_dir)
         self.max_shards = max_shards
         self.shard_size = shard_size
-        
+
         # Ensure directories exist
         self.selfplay_dir = self.base_dir / "selfplay"
         self.replays_dir = self.base_dir / "replays"
         self.validation_dir = self.base_dir / "validation"
         self.backups_dir = self.base_dir / "backups"
-        
+
         for dir_path in [self.selfplay_dir, self.replays_dir, self.validation_dir, self.backups_dir]:
             dir_path.mkdir(parents=True, exist_ok=True)
-        
+
         # Initialize database for tracking
         self.db_path = self.base_dir / "data_metadata.db"
         self._init_database()
-        
+
         # Version tracking
         self.version = "1.0.0"
-        
-    from __future__ import annotations
 
-import os
-import json
-import hashlib
-import sqlite3
-from dataclasses import dataclass, asdict
-from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Iterator
-from datetime import datetime
-import numpy as np
-import logging
-import argparse
-import time
-
-logger = logging.getLogger(__name__)
-
-
-@dataclass
-class DataShard:
-    """Represents a single data shard with metadata."""
-    path: str
-    size_bytes: int
-    sample_count: int
-    created_at: str
-    checksum: str
-    version: str
-    corrupted: bool = False
-
-
-@dataclass
-class DataStats:
-    """Statistics about the data pipeline."""
-    total_shards: int
-    total_samples: int
-    total_size_gb: float
-    corrupted_shards: int
-    last_updated: str
-
-
-class DataManager:
-    """Manages the replay buffer and data pipeline for Matrix0 training."""
-    
-    def __init__(self, base_dir: str = "data", max_shards: int = 128, shard_size: int = 16384):
-        self.base_dir = Path(base_dir)
-        self.max_shards = max_shards
-        self.shard_size = shard_size
-        
-        # Ensure directories exist
-        self.selfplay_dir = self.base_dir / "selfplay"
-        self.replays_dir = self.base_dir / "replays"
-        self.validation_dir = self.base_dir / "validation"
-        self.backups_dir = self.base_dir / "backups"
-        
-        for dir_path in [self.selfplay_dir, self.replays_dir, self.validation_dir, self.backups_dir]:
-            dir_path.mkdir(parents=True, exist_ok=True)
-        
-        # Initialize database for tracking
-        self.db_path = self.base_dir / "data_metadata.db"
-        self._init_database()
-        
-        # Version tracking
-        self.version = "1.0.0"
-        
     def _connect(self) -> sqlite3.Connection:
         """Create a SQLite connection with WAL and busy timeout enabled."""
         conn = sqlite3.connect(self.db_path, timeout=30)
@@ -142,7 +77,7 @@ class DataManager:
         """Initialize SQLite database for metadata tracking."""
         conn = self._connect()
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS shards (
                 path TEXT PRIMARY KEY,
@@ -156,7 +91,7 @@ class DataManager:
                 last_accessed TEXT
             )
         """)
-        
+
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS data_stats (
                 key TEXT PRIMARY KEY,
@@ -164,7 +99,7 @@ class DataManager:
                 updated_at TEXT
             )
         """)
-        
+
         conn.commit()
 
         # Lightweight migration: ensure expected columns exist
@@ -208,62 +143,62 @@ class DataManager:
                     delay = min(0.5, delay * 2)
                 else:
                     raise
-    
+
     def add_selfplay_data(self, data: Dict[str, np.ndarray], worker_id: int, game_id: int) -> str:
         """Add self-play data to the buffer."""
         # Use filesystem-safe timestamp
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = f"selfplay_w{worker_id}_g{game_id}_{timestamp}.npz"
         filepath = self.selfplay_dir / filename
-        
+
         # Save atomically: write to temp then move
         tmp_path = filepath.with_suffix('.npz.tmp')
         np.savez_compressed(tmp_path, **data)
         tmp_path.replace(filepath)
-        
+
         # Calculate metadata
         file_size = filepath.stat().st_size
         sample_count = len(data.get('s', []))
         checksum = self._calculate_checksum(filepath)
-        
+
         # Record in database
         self._record_shard(str(filepath), file_size, sample_count, timestamp, checksum, source="selfplay")
-        
+
         logger.info(f"Added self-play data: {filename} ({sample_count} samples, {file_size/1024:.1f}KB)")
         return str(filepath)
-    
+
     def add_training_data(self, data: Dict[str, np.ndarray], shard_id: int, source: str = "selfplay") -> str:
         """Add processed training data to replay buffer."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         filename = f"replay_{shard_id:06d}_{timestamp}.npz"
         filepath = self.replays_dir / filename
-        
+
         # Save atomically
         tmp_path = filepath.with_suffix('.npz.tmp')
         np.savez_compressed(tmp_path, **data)
         tmp_path.replace(filepath)
-        
+
         # Calculate metadata
         file_size = filepath.stat().st_size
         sample_count = len(data.get('s', []))
         checksum = self._calculate_checksum(filepath)
-        
+
         # Record in database
         self._record_shard(str(filepath), file_size, sample_count, timestamp, checksum, source=source)
-        
+
         logger.info(f"Added training data: {filename} ({sample_count} samples, {file_size/1024:.1f}KB)")
         return str(filepath)
-    
+
     def get_training_batch(self, batch_size: int, device: str = "cpu") -> Iterator[Tuple[np.ndarray, np.ndarray, np.ndarray]]:
         """Get training batches from replay buffer."""
         shard_paths = self._get_valid_shard_paths()
-        
+
         if not shard_paths:
             raise RuntimeError("No valid training data available")
-        
+
         # Randomly sample from shards
         np.random.shuffle(shard_paths)
-        
+
         for shard_path in shard_paths:
             try:
                 # Memory-map to reduce RSS and speed IO
@@ -271,38 +206,38 @@ class DataManager:
                     states = data['s']
                     policies = data['pi']
                     values = data['z']
-                    
+
                     # Shuffle within shard
                     indices = np.random.permutation(len(states))
                     states = states[indices]
                     policies = policies[indices]
                     values = values[indices]
-                    
+
                     # Yield batches
                     for i in range(0, len(states), batch_size):
                         batch_states = states[i:i+batch_size]
                         batch_policies = policies[i:i+batch_size]
                         batch_values = values[i:i+batch_size]
-                        
+
                         if len(batch_states) == batch_size:
                             yield batch_states, batch_policies, batch_values
-                            
+
             except Exception as e:
                 logger.error(f"Error loading shard {shard_path}: {e}")
                 self._mark_shard_corrupted(shard_path)
                 continue
-    
+
     def cleanup_old_shards(self, keep_recent: int = 64):
         """Remove old shards to maintain storage limits."""
         shards = self._get_all_shards()
-        
+
         if len(shards) <= keep_recent:
             return
-        
+
         # Sort by creation time, keep most recent
         shards.sort(key=lambda x: x.created_at, reverse=True)
         to_remove = shards[keep_recent:]
-        
+
         for shard in to_remove:
             try:
                 Path(shard.path).unlink()
@@ -310,13 +245,13 @@ class DataManager:
                 logger.info(f"Removed old shard: {shard.path}")
             except Exception as e:
                 logger.error(f"Error removing shard {shard.path}: {e}")
-    
+
     def validate_data_integrity(self) -> Tuple[int, int]:
         """Validate all shards and return (valid, corrupted) counts."""
         shards = self._get_all_shards()
         valid_count = 0
         corrupted_count = 0
-        
+
         for shard in shards:
             try:
                 if self._validate_shard(shard):
@@ -328,40 +263,18 @@ class DataManager:
                 logger.error(f"Error validating shard {shard.path}: {e}")
                 corrupted_count += 1
                 self._mark_shard_corrupted(shard.path)
-        
-        return valid_count, corrupted_count
 
-    def quarantine_corrupted_shards(self) -> int:
-        """Moves corrupted shards to a quarantine directory."""
-        quarantine_dir = self.backups_dir / "quarantine"
-        quarantine_dir.mkdir(parents=True, exist_ok=True)
-        
-        shards = self._get_all_shards()
-        quarantined_count = 0
-        
-        for shard in shards:
-            if shard.corrupted:
-                try:
-                    shard_path = Path(shard.path)
-                    if shard_path.exists():
-                        new_path = quarantine_dir / shard_path.name
-                        shard_path.rename(new_path)
-                        logger.info(f"Quarantined corrupted shard: {shard.path} to {new_path}")
-                        quarantined_count += 1
-                except Exception as e:
-                    logger.error(f"Error quarantining shard {shard.path}: {e}")
-        
-        return quarantined_count
+        return valid_count, corrupted_count
 
     def get_stats(self) -> DataStats:
         """Get current data pipeline statistics."""
         shards = self._get_all_shards()
-        
+
         total_shards = len(shards)
         total_samples = sum(s.sample_count for s in shards)
         total_size_gb = sum(s.size_bytes for s in shards) / (1024**3)
         corrupted_shards = sum(1 for s in shards if s.corrupted)
-        
+
         return DataStats(
             total_shards=total_shards,
             total_samples=total_samples,
@@ -369,17 +282,17 @@ class DataManager:
             corrupted_shards=corrupted_shards,
             last_updated=datetime.now().isoformat()
         )
-    
+
     def create_backup(self) -> str:
         """Create a backup of the current data state."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         backup_dir = self.backups_dir / f"backup_{timestamp}"
         backup_dir.mkdir(exist_ok=True)
-        
+
         # Copy database
         import shutil
         shutil.copy2(self.db_path, backup_dir / "data_metadata.db")
-        
+
         # Create manifest
         manifest = {
             "timestamp": timestamp,
@@ -387,10 +300,10 @@ class DataManager:
             "stats": asdict(self.get_stats()),
             "shards": [asdict(s) for s in self._get_all_shards()]
         }
-        
+
         with open(backup_dir / "manifest.json", "w") as f:
             json.dump(manifest, f, indent=2)
-        
+
         logger.info(f"Created backup: {backup_dir}")
         return str(backup_dir)
 
@@ -441,7 +354,7 @@ class DataManager:
                 buf_pi = [pi_cat[take:]]
                 buf_z = [z_cat[take:]]
                 count = s_cat.shape[0] - take
-                
+
                 self.add_training_data({"s": shard_s, "pi": shard_pi, "z": shard_z}, next_idx)
                 next_idx += 1
 
@@ -488,7 +401,7 @@ class DataManager:
                 logger.error(f"Failed to import shard {f}: {e}")
         return count
 
-    def _record_shard(self, path: str, size_bytes: int, sample_count: int, 
+    def _record_shard(self, path: str, size_bytes: int, sample_count: int,
                       created_at: str, checksum: str, source: str = "selfplay"):
         """Record shard metadata in database."""
         conn = self._connect()
@@ -496,26 +409,26 @@ class DataManager:
         def _do():
             cursor.execute(
                 """
-                INSERT OR REPLACE INTO shards 
+                INSERT OR REPLACE INTO shards
                 (path, size_bytes, sample_count, created_at, checksum, version, source, last_accessed)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (path, size_bytes, sample_count, created_at, checksum, self.version, source, created_at)
+                (path, size_bytes, sample_count, created_at, checksum, self.version, source, created_at),
             )
             conn.commit()
         self._with_retry(_do)
         conn.close()
-    
+
     def _get_valid_shard_paths(self) -> List[str]:
         """Get paths of valid (non-corrupted) shards."""
         conn = self._connect()
         cursor = conn.cursor()
-        
+
         cursor.execute("SELECT path FROM shards WHERE corrupted = FALSE ORDER BY created_at DESC")
         paths = [row[0] for row in cursor.fetchall()]
-        
+
         conn.close()
-        
+
         # Filter out paths that don't exist on disk
         valid_paths = []
         for path in paths:
@@ -524,19 +437,19 @@ class DataManager:
             else:
                 # Mark as corrupted if file doesn't exist
                 self._mark_shard_corrupted(path)
-        
+
         return valid_paths
-    
+
     def _get_all_shards(self) -> List[DataShard]:
         """Get all shards with metadata."""
         conn = self._connect()
         cursor = conn.cursor()
-        
+
         cursor.execute("""
             SELECT path, size_bytes, sample_count, created_at, checksum, version, corrupted
             FROM shards ORDER BY created_at DESC
         """)
-        
+
         shards = []
         for row in cursor.fetchall():
             shards.append(DataShard(
@@ -548,10 +461,10 @@ class DataManager:
                 version=row[5],
                 corrupted=bool(row[6])
             ))
-        
+
         conn.close()
         return shards
-    
+
     def _calculate_checksum(self, filepath: Path) -> str:
         """Calculate SHA256 checksum of file."""
         sha256_hash = hashlib.sha256()
@@ -559,55 +472,55 @@ class DataManager:
             for chunk in iter(lambda: f.read(4096), b""):
                 sha256_hash.update(chunk)
         return sha256_hash.hexdigest()
-    
+
     def _validate_shard(self, shard: DataShard) -> bool:
         """Validate a single shard's integrity."""
         try:
             filepath = Path(shard.path)
             if not filepath.exists():
                 return False
-            
+
             # Check file size
             if filepath.stat().st_size != shard.size_bytes:
                 return False
-            
+
             # Check checksum
             current_checksum = self._calculate_checksum(filepath)
             if current_checksum != shard.checksum:
                 return False
-            
+
             # Try to load data
             with np.load(filepath) as data:
                 required_keys = ['s', 'pi', 'z']
                 if not all(key in data for key in required_keys):
                     return False
-                
+
                 # Check sample count
                 if len(data['s']) != shard.sample_count:
                     return False
-            
+
             return True
-            
+
         except Exception:
             return False
-    
+
     def _mark_shard_corrupted(self, path: str):
         """Mark a shard as corrupted in the database."""
         conn = self._connect()
         cursor = conn.cursor()
-        
+
         cursor.execute("UPDATE shards SET corrupted = TRUE WHERE path = ?", (path,))
-        
+
         conn.commit()
         conn.close()
-    
+
     def _remove_shard_record(self, path: str):
         """Remove a shard record from the database."""
         conn = self._connect()
         cursor = conn.cursor()
-        
+
         cursor.execute("DELETE FROM shards WHERE path = ?", (path,))
-        
+
         conn.commit()
         conn.close()
 
@@ -634,6 +547,7 @@ class DataManager:
                 continue
         conn.close()
         return count
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Matrix0 Data Manager CLI")
@@ -652,532 +566,3 @@ if __name__ == "__main__":
         count = dm.quarantine_corrupted_shards()
         print(f"Quarantined {count} corrupted shards.")
 
-    def _init_database(self):
-        """Initialize SQLite database for metadata tracking."""
-        conn = self._connect()
-        cursor = conn.cursor()
-        
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS shards (
-                path TEXT PRIMARY KEY,
-                size_bytes INTEGER,
-                sample_count INTEGER,
-                created_at TEXT,
-                checksum TEXT,
-                version TEXT,
-                source TEXT,
-                corrupted BOOLEAN DEFAULT FALSE,
-                last_accessed TEXT
-            )
-        """)
-        
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS data_stats (
-                key TEXT PRIMARY KEY,
-                value TEXT,
-                updated_at TEXT
-            )
-        """)
-        
-        conn.commit()
-
-        # Lightweight migration: ensure expected columns exist
-        try:
-            cursor.execute("PRAGMA table_info(shards)")
-            cols = {row[1] for row in cursor.fetchall()}  # column names
-            migrations = []
-            if 'source' not in cols:
-                migrations.append("ALTER TABLE shards ADD COLUMN source TEXT")
-            if 'corrupted' not in cols:
-                migrations.append("ALTER TABLE shards ADD COLUMN corrupted BOOLEAN DEFAULT FALSE")
-            if 'last_accessed' not in cols:
-                migrations.append("ALTER TABLE shards ADD COLUMN last_accessed TEXT")
-            if 'version' not in cols:
-                migrations.append("ALTER TABLE shards ADD COLUMN version TEXT")
-            for sql in migrations:
-                try:
-                    cursor.execute(sql)
-                except Exception:
-                    pass
-            if migrations:
-                conn.commit()
-        except Exception:
-            pass
-        conn.close()
-
-    def _with_retry(self, func, *args, **kwargs):
-        """Retry a DB operation if the database is locked."""
-        attempts = 0
-        delay = 0.05
-        while True:
-            try:
-                return func(*args, **kwargs)
-            except sqlite3.OperationalError as e:
-                msg = str(e).lower()
-                if 'locked' in msg or 'busy' in msg:
-                    attempts += 1
-                    if attempts > 10:
-                        raise
-                    time.sleep(delay)
-                    delay = min(0.5, delay * 2)
-                else:
-                    raise
-    
-    def add_selfplay_data(self, data: Dict[str, np.ndarray], worker_id: int, game_id: int) -> str:
-        """Add self-play data to the buffer."""
-        # Use filesystem-safe timestamp
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"selfplay_w{worker_id}_g{game_id}_{timestamp}.npz"
-        filepath = self.selfplay_dir / filename
-        
-        # Save atomically: write to temp then move
-        tmp_path = filepath.with_suffix('.npz.tmp')
-        np.savez_compressed(tmp_path, **data)
-        tmp_path.replace(filepath)
-        
-        # Calculate metadata
-        file_size = filepath.stat().st_size
-        sample_count = len(data.get('s', []))
-        checksum = self._calculate_checksum(filepath)
-        
-        # Record in database
-        self._record_shard(str(filepath), file_size, sample_count, timestamp, checksum, source="selfplay")
-        
-        logger.info(f"Added self-play data: {filename} ({sample_count} samples, {file_size/1024:.1f}KB)")
-        return str(filepath)
-    
-    def add_training_data(self, data: Dict[str, np.ndarray], shard_id: int, source: str = "selfplay") -> str:
-        """Add processed training data to replay buffer."""
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"replay_{shard_id:06d}_{timestamp}.npz"
-        filepath = self.replays_dir / filename
-        
-        # Save atomically
-        tmp_path = filepath.with_suffix('.npz.tmp')
-        np.savez_compressed(tmp_path, **data)
-        tmp_path.replace(filepath)
-        
-        # Calculate metadata
-        file_size = filepath.stat().st_size
-        sample_count = len(data.get('s', []))
-        checksum = self._calculate_checksum(filepath)
-        
-        # Record in database
-        self._record_shard(str(filepath), file_size, sample_count, timestamp, checksum, source=source)
-        
-        logger.info(f"Added training data: {filename} ({sample_count} samples, {file_size/1024:.1f}KB)")
-        return str(filepath)
-    
-    def get_training_batch(self, batch_size: int, device: str = "cpu") -> Iterator[Tuple[np.ndarray, np.ndarray, np.ndarray]]:
-        """Get training batches from replay buffer."""
-        shard_paths = self._get_valid_shard_paths()
-        
-        if not shard_paths:
-            raise RuntimeError("No valid training data available")
-        
-        # Randomly sample from shards
-        np.random.shuffle(shard_paths)
-        
-        for shard_path in shard_paths:
-            try:
-                # Memory-map to reduce RSS and speed IO
-                with np.load(shard_path, mmap_mode='r') as data:
-                    states = data['s']
-                    policies = data['pi']
-                    values = data['z']
-                    
-                    # Shuffle within shard
-                    indices = np.random.permutation(len(states))
-                    states = states[indices]
-                    policies = policies[indices]
-                    values = values[indices]
-                    
-                    # Yield batches
-                    for i in range(0, len(states), batch_size):
-                        batch_states = states[i:i+batch_size]
-                        batch_policies = policies[i:i+batch_size]
-                        batch_values = values[i:i+batch_size]
-                        
-                        if len(batch_states) == batch_size:
-                            yield batch_states, batch_policies, batch_values
-                            
-            except Exception as e:
-                logger.error(f"Error loading shard {shard_path}: {e}")
-                self._mark_shard_corrupted(shard_path)
-                continue
-    
-    def cleanup_old_shards(self, keep_recent: int = 64):
-        """Remove old shards to maintain storage limits."""
-        shards = self._get_all_shards()
-        
-        if len(shards) <= keep_recent:
-            return
-        
-        # Sort by creation time, keep most recent
-        shards.sort(key=lambda x: x.created_at, reverse=True)
-        to_remove = shards[keep_recent:]
-        
-        for shard in to_remove:
-            try:
-                Path(shard.path).unlink()
-                self._remove_shard_record(shard.path)
-                logger.info(f"Removed old shard: {shard.path}")
-            except Exception as e:
-                logger.error(f"Error removing shard {shard.path}: {e}")
-    
-    def validate_data_integrity(self) -> Tuple[int, int]:
-        """Validate all shards and return (valid, corrupted) counts."""
-        shards = self._get_all_shards()
-        valid_count = 0
-        corrupted_count = 0
-        
-        for shard in shards:
-            try:
-                if self._validate_shard(shard):
-                    valid_count += 1
-                else:
-                    corrupted_count += 1
-                    self._mark_shard_corrupted(shard.path)
-            except Exception as e:
-                logger.error(f"Error validating shard {shard.path}: {e}")
-                corrupted_count += 1
-                self._mark_shard_corrupted(shard.path)
-        
-        return valid_count, corrupted_count
-
-    def quarantine_corrupted_shards(self) -> int:
-        """Moves corrupted shards to a quarantine directory."""
-        quarantine_dir = self.backups_dir / "quarantine"
-        quarantine_dir.mkdir(parents=True, exist_ok=True)
-        
-        shards = self._get_all_shards()
-        quarantined_count = 0
-        
-        for shard in shards:
-            if shard.corrupted:
-                try:
-                    shard_path = Path(shard.path)
-                    if shard_path.exists():
-                        new_path = quarantine_dir / shard_path.name
-                        shard_path.rename(new_path)
-                        logger.info(f"Quarantined corrupted shard: {shard.path} to {new_path}")
-                        quarantined_count += 1
-                except Exception as e:
-                    logger.error(f"Error quarantining shard {shard.path}: {e}")
-        
-        return quarantined_count
-
-    def get_stats(self) -> DataStats:
-        """Get current data pipeline statistics."""
-        shards = self._get_all_shards()
-        
-        total_shards = len(shards)
-        total_samples = sum(s.sample_count for s in shards)
-        total_size_gb = sum(s.size_bytes for s in shards) / (1024**3)
-        corrupted_shards = sum(1 for s in shards if s.corrupted)
-        
-        return DataStats(
-            total_shards=total_shards,
-            total_samples=total_samples,
-            total_size_gb=total_size_gb,
-            corrupted_shards=corrupted_shards,
-            last_updated=datetime.now().isoformat()
-        )
-    
-    def create_backup(self) -> str:
-        """Create a backup of the current data state."""
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        backup_dir = self.backups_dir / f"backup_{timestamp}"
-        backup_dir.mkdir(exist_ok=True)
-        
-        # Copy database
-        import shutil
-        shutil.copy2(self.db_path, backup_dir / "data_metadata.db")
-        
-        # Create manifest
-        manifest = {
-            "timestamp": timestamp,
-            "version": self.version,
-            "stats": asdict(self.get_stats()),
-            "shards": [asdict(s) for s in self._get_all_shards()]
-        }
-        
-        with open(backup_dir / "manifest.json", "w") as f:
-            json.dump(manifest, f, indent=2)
-        
-        logger.info(f"Created backup: {backup_dir}")
-        return str(backup_dir)
-
-    def compact_selfplay_to_replay(self):
-        """Compacts self-play games into larger replay shards."""
-        sp_files = sorted([x for x in self.selfplay_dir.glob("*.npz") if x.is_file()])
-        if not sp_files:
-            return
-
-        # Determine next shard index
-        existing = sorted(self.replays_dir.glob("shard_*.npz"))
-        next_idx = 0
-        if existing:
-            last = existing[-1]
-            try:
-                next_idx = int(last.stem.split("_")[-1]) + 1
-            except Exception:
-                next_idx = len(existing)
-
-        buf_s, buf_pi, buf_z = [], [], []
-        count = 0
-        for f in sp_files:
-            try:
-                with np.load(f) as data:
-                    s, pi, z = data["s"], data["pi"], data["z"]
-                buf_s.append(s)
-                buf_pi.append(pi)
-                buf_z.append(z)
-                count += s.shape[0]
-                # Move source file to backup instead of deleting
-                backup_path = self.backups_dir / f.name
-                backup_path.write_bytes(f.read_bytes())
-                f.unlink(missing_ok=True)
-            except Exception as e:
-                logger.error(f"Error processing selfplay file {f}: {e}")
-                self._mark_shard_corrupted(str(f))
-                continue
-
-            # Flush if buffer is large
-            while count >= self.shard_size:
-                take = self.shard_size
-                s_cat = np.concatenate(buf_s, axis=0)
-                pi_cat = np.concatenate(buf_pi, axis=0)
-                z_cat = np.concatenate(buf_z, axis=0)
-                shard_s, shard_pi, shard_z = s_cat[:take], pi_cat[:take], z_cat[:take]
-                # Keep leftovers
-                buf_s = [s_cat[take:]]
-                buf_pi = [pi_cat[take:]]
-                buf_z = [z_cat[take:]]
-                count = s_cat.shape[0] - take
-                
-                self.add_training_data({"s": shard_s, "pi": shard_pi, "z": shard_z}, next_idx)
-                next_idx += 1
-
-        # Flush tail
-        if count > 0:
-            s_cat = np.concatenate(buf_s, axis=0)
-            pi_cat = np.concatenate(buf_pi, axis=0)
-            z_cat = np.concatenate(buf_z, axis=0)
-            self.add_training_data({"s": s_cat, "pi": pi_cat, "z": z_cat}, next_idx)
-
-        # Enforce max shards (keep most recent)
-        self.cleanup_old_shards(keep_recent=self.max_shards)
-
-    def import_replay_dir(self, src_dir: str, source: str = "external", move_files: bool = False) -> int:
-        """Import existing NPZ shards from a directory into the replay buffer and DB.
-
-        If move_files is True, files are moved into the managed replay directory; otherwise
-        they are left in place and simply recorded in the DB so training can read them.
-
-        Returns number of files imported.
-        """
-        src = Path(src_dir)
-        if not src.exists():
-            return 0
-        count = 0
-        for f in sorted(src.glob('*.npz')):
-            try:
-                dest_path = f
-                if move_files:
-                    dest_path = self.replays_dir / f.name
-                    if dest_path.resolve() != f.resolve():
-                        dest_path.write_bytes(f.read_bytes())
-                        f.unlink(missing_ok=True)
-                # Load to get sample count quickly
-                with np.load(dest_path, mmap_mode='r') as data:
-                    s = data['s']
-                    sample_count = int(s.shape[0])
-                size_bytes = dest_path.stat().st_size
-                ts = datetime.now().isoformat()
-                checksum = self._calculate_checksum(dest_path)
-                self._record_shard(str(dest_path), size_bytes, sample_count, ts, checksum, source=source)
-                count += 1
-            except Exception as e:
-                logger.error(f"Failed to import shard {f}: {e}")
-        return count
-
-    def _record_shard(self, path: str, size_bytes: int, sample_count: int, 
-                      created_at: str, checksum: str, source: str = "selfplay"):
-        """Record shard metadata in database."""
-        conn = self._connect()
-        cursor = conn.cursor()
-        def _do():
-            cursor.execute(
-                """
-                INSERT OR REPLACE INTO shards 
-                (path, size_bytes, sample_count, created_at, checksum, version, source, last_accessed)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (path, size_bytes, sample_count, created_at, checksum, self.version, source, created_at)
-            )
-            conn.commit()
-        self._with_retry(_do)
-        conn.close()
-    
-    def _get_valid_shard_paths(self) -> List[str]:
-        """Get paths of valid (non-corrupted) shards."""
-        conn = self._connect()
-        cursor = conn.cursor()
-        
-        cursor.execute("SELECT path FROM shards WHERE corrupted = FALSE ORDER BY created_at DESC")
-        paths = [row[0] for row in cursor.fetchall()]
-        
-        conn.close()
-        
-        # Filter out paths that don't exist on disk
-        valid_paths = []
-        for path in paths:
-            if Path(path).exists():
-                valid_paths.append(path)
-            else:
-                # Mark as corrupted if file doesn't exist
-                self._mark_shard_corrupted(path)
-        
-        return valid_paths
-    
-    def _get_all_shards(self) -> List[DataShard]:
-        """Get all shards with metadata."""
-        conn = self._connect()
-        cursor = conn.cursor()
-        
-        cursor.execute("""
-            SELECT path, size_bytes, sample_count, created_at, checksum, version, corrupted
-            FROM shards ORDER BY created_at DESC
-        """)
-        
-        shards = []
-        for row in cursor.fetchall():
-            shards.append(DataShard(
-                path=row[0],
-                size_bytes=row[1],
-                sample_count=row[2],
-                created_at=row[3],
-                checksum=row[4],
-                version=row[5],
-                corrupted=bool(row[6])
-            ))
-        
-        conn.close()
-        return shards
-    
-    def _calculate_checksum(self, filepath: Path) -> str:
-        """Calculate SHA256 checksum of file."""
-        sha256_hash = hashlib.sha256()
-        with open(filepath, "rb") as f:
-            for chunk in iter(lambda: f.read(4096), b""):
-                sha256_hash.update(chunk)
-        return sha256_hash.hexdigest()
-    
-    def _validate_shard(self, shard: DataShard) -> bool:
-        """Validate a single shard's integrity."""
-        try:
-            filepath = Path(shard.path)
-            if not filepath.exists():
-                return False
-            
-            # Check file size
-            if filepath.stat().st_size != shard.size_bytes:
-                return False
-            
-            # Check checksum
-            current_checksum = self._calculate_checksum(filepath)
-            if current_checksum != shard.checksum:
-                return False
-            
-            # Try to load data
-            with np.load(filepath) as data:
-                required_keys = ['s', 'pi', 'z']
-                if not all(key in data for key in required_keys):
-                    return False
-                
-                # Check sample count
-                if len(data['s']) != shard.sample_count:
-                    return False
-            
-            return True
-            
-        except Exception:
-            return False
-    
-    def _mark_shard_corrupted(self, path: str):
-        """Mark a shard as corrupted in the database."""
-        conn = self._connect()
-        cursor = conn.cursor()
-        
-        cursor.execute("UPDATE shards SET corrupted = TRUE WHERE path = ?", (path,))
-        
-        conn.commit()
-        conn.close()
-    
-    def _remove_shard_record(self, path: str):
-        """Remove a shard record from the database."""
-        conn = self._connect()
-        cursor = conn.cursor()
-        
-        cursor.execute("DELETE FROM shards WHERE path = ?", (path,))
-        
-        conn.commit()
-        conn.close()
-
-    def quarantine_corrupted_shards(self, quarantine_dir: str | None = None) -> int:
-        """Move corrupted shards to a quarantine directory and remove their DB records.
-
-        Returns number of files quarantined.
-        """
-        qdir = Path(quarantine_dir or (self.backups_dir / "quarantine"))
-        qdir.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(self.db_path)
-        cursor = conn.cursor()
-        cursor.execute("SELECT path FROM shards WHERE corrupted = TRUE")
-        rows = cursor.fetchall()
-        count = 0
-        for (pstr,) in rows:
-            p = Path(pstr)
-            try:
-                if p.exists():
-                    p.rename(qdir / p.name)
-                self._remove_shard_record(pstr)
-                count += 1
-            except Exception:
-                continue
-        conn.close()
-        return count
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Matrix0 Data Manager CLI")
-    parser.add_argument("--base-dir", type=str, default="data", help="Base data directory")
-    parser.add_argument("--action", type=str, required=True,
-                        choices=["stats", "validate", "quarantine", "compact", "backup", "import"],
-                        help="Action to perform")
-    parser.add_argument("--path", type=str, default=None, help="Path for import action")
-    args = parser.parse_args()
-
-    dm = DataManager(base_dir=args.base_dir)
-
-    if args.action == "stats":
-        stats = dm.get_stats()
-        print(json.dumps(asdict(stats), indent=2))
-    elif args.action == "validate":
-        valid, corrupted = dm.validate_data_integrity()
-        print(f"Validation complete. Valid shards: {valid}, Corrupted shards: {corrupted}")
-    elif args.action == "quarantine":
-        count = dm.quarantine_corrupted_shards()
-        print(f"Quarantined {count} corrupted shards.")
-    elif args.action == "compact":
-        dm.compact_selfplay_to_replay()
-        stats = dm.get_stats()
-        print(json.dumps(asdict(stats), indent=2))
-    elif args.action == "backup":
-        path = dm.create_backup()
-        print(json.dumps({"backup": path}, indent=2))
-    elif args.action == "import":
-        if not args.path:
-            raise SystemExit("--path required for import action")
-        n = dm.import_replay_dir(args.path, source="external", move_files=False)
-        print(json.dumps({"imported": n, "from": args.path}, indent=2))


### PR DESCRIPTION
## Summary
- Deduplicate `data_manager.py` by removing a spurious repeated block and unused imports
- Retain single definitions for data shard structures and DataManager methods
- Keep only necessary imports and eliminate duplicates

## Testing
- `python -m py_compile azchess/data_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49249e8e88323acd9c311d54542c8