### PR TITLE
Add temporary NPZ cleanup script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VENV_DIR=.venv
 PIP=$(VENV_DIR)/bin/pip
 PYTHON_EXEC=$(VENV_DIR)/bin/python
 
-.PHONY: help install setup train selfplay data-stats lint download-lichess
+.PHONY: help install setup train selfplay data-stats lint download-lichess cleanup-temp-npz
 
 help:
 	@echo "Matrix0 Makefile"
@@ -15,6 +15,7 @@ help:
 	@echo "data-stats     - Display statistics about the training data."
 	@echo "lint           - Run linter and code formatter (requires ruff)."
 	@echo "download-lichess - Download a month of Lichess data (e.g., make download-lichess MONTH=2023-01)."
+	@echo "cleanup-temp-npz - Remove stray temporary .npz files from the data directory."
 
 # Environment and Installation
 setup: $(VENV_DIR)/bin/activate
@@ -47,6 +48,10 @@ data-stats:
 download-lichess:
 	@echo "Downloading Lichess data for month: $(MONTH)"
 	$(PYTHON_EXEC) azchess/tools/process_lichess.py download $(MONTH)
+
+cleanup-temp-npz:
+	@echo "Cleaning up temporary NPZ files..."
+	$(PYTHON_EXEC) scripts/cleanup_temp_npz.py
 
 # Code Quality
 lint:

--- a/scripts/cleanup_temp_npz.py
+++ b/scripts/cleanup_temp_npz.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Clean up stray temporary NPZ files.
+
+Recursively search a data directory for ``*.npz.tmp`` or ``*.npz.tmp.npz`` files.
+If a matching final ``.npz`` file does not exist, remove the temporary file or
+optionally move it to a quarantine directory.  A dry-run mode is available to
+preview actions without modifying the filesystem.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+import shutil
+
+
+def find_temp_files(root: Path):
+    """Yield temporary NPZ files under ``root``."""
+    patterns = ["*.npz.tmp", "*.npz.tmp.npz"]
+    for pattern in patterns:
+        yield from root.rglob(pattern)
+
+
+def resolve_final_path(temp_path: Path) -> Path:
+    """Return the expected final ``.npz`` path for ``temp_path``."""
+    if temp_path.name.endswith(".npz.tmp"):
+        return Path(str(temp_path)[:-4])  # strip ".tmp"
+    if temp_path.name.endswith(".npz.tmp.npz"):
+        return Path(str(temp_path)[:-8])  # strip ".tmp.npz"
+    return temp_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir",
+        default="data",
+        type=Path,
+        help="Directory to scan recursively for temporary NPZ files.",
+    )
+    parser.add_argument(
+        "--quarantine-dir",
+        type=Path,
+        help="If set, move files here instead of deleting them.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show actions without deleting or moving files.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Increase logging verbosity.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    root = args.data_dir
+    if not root.exists():
+        logging.error("Data directory %s does not exist", root)
+        return 1
+
+    quarantine_dir = args.quarantine_dir
+    if quarantine_dir and not quarantine_dir.exists():
+        if args.dry_run:
+            logging.info(
+                "[dry-run] Would create quarantine directory %s", quarantine_dir
+            )
+        else:
+            quarantine_dir.mkdir(parents=True, exist_ok=True)
+
+    processed = 0
+    for temp_path in find_temp_files(root):
+        final_path = resolve_final_path(temp_path)
+        if final_path.exists():
+            logging.debug("Skipping %s because %s exists", temp_path, final_path)
+            continue
+
+        if args.dry_run:
+            logging.info("[dry-run] Removing %s", temp_path)
+            processed += 1
+            continue
+
+        try:
+            if quarantine_dir:
+                dest = quarantine_dir / temp_path.name
+                shutil.move(str(temp_path), dest)
+                logging.info("Moved %s to %s", temp_path, dest)
+            else:
+                temp_path.unlink()
+                logging.info("Removed %s", temp_path)
+            processed += 1
+        except Exception as exc:  # pragma: no cover
+            logging.error("Failed to process %s: %s", temp_path, exc)
+
+    logging.info("Processed %d temporary files", processed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `cleanup_temp_npz.py` to remove orphaned `*.npz.tmp*` artifacts with optional quarantine and dry-run
- expose a `cleanup-temp-npz` make target for scheduled maintenance

## Testing
- `python scripts/cleanup_temp_npz.py --dry-run 2>&1 | tail -n 5`
- `pytest`
- `make lint` *(fails: Found 119 errors.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4925d410c83239ce4076177442d21