### PR TITLE
Use logging for model info tool

### DIFF
--- a/azchess/tools/model_info.py
+++ b/azchess/tools/model_info.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import logging
+import sys
+
 from azchess.config import Config
 from azchess.model import PolicyValueNet
+
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -13,16 +19,17 @@ def main():
     cfg = Config.load(args.config)
     model = PolicyValueNet.from_config(cfg.model())
     params = model.count_parameters()
-    print("Model config:")
+    logger.info("Model config:")
     for k, v in cfg.model().items():
-        print(f"  {k}: {v}")
-    print(f"Total parameters: {params:,}")
+        logger.info(f"  {k}: {v}")
+    logger.info(f"Total parameters: {params:,}")
     bytes_fp32 = params * 4
     bytes_fp16 = params * 2
-    print(f"Approx size FP32: {bytes_fp32/1e6:.1f} MB")
-    print(f"Approx size FP16: {bytes_fp16/1e6:.1f} MB")
+    logger.info(f"Approx size FP32: {bytes_fp32/1e6:.1f} MB")
+    logger.info(f"Approx size FP16: {bytes_fp16/1e6:.1f} MB")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
     main()
 


### PR DESCRIPTION
## Summary
- add module-level logger to `model_info` utility
- swap user `print` statements for `logger.info`
- configure logging in main block for CLI output

## Testing
- `pytest -q`
- `python -m azchess.tools.model_info --config config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a5fcbf39c88323a1d22bdf9cfd4516