### PR TITLE
Use unified MCTSConfig from shared config

### DIFF
--- a/analyze_arena_games.py
+++ b/analyze_arena_games.py
@@ -33,19 +33,16 @@ def analyze_single_game(ckpt_a_path: str, ckpt_b_path: str, game_idx: int = 0,
     from azchess.config import select_device
     
     device = select_device(device)
-    mcfg = MCTSConfig(
-        num_simulations=num_sims,
-        cpuct=float(cfg.mcts().get("cpuct", 1.5)),
-        dirichlet_alpha=float(cfg.mcts().get("dirichlet_alpha", 0.3)),
-        dirichlet_frac=float(cfg.mcts().get("dirichlet_frac", 0.25)),
-        tt_capacity=int(cfg.mcts().get("tt_capacity", 200000)),
-        selection_jitter=float(cfg.selfplay().get("selection_jitter", 0.0)),
-        batch_size=batch_size,
-        fpu=float(cfg.mcts().get("fpu", 0.5)),
-        parent_q_init=bool(cfg.mcts().get("parent_q_init", True)),
-        tt_cleanup_frequency=int(cfg.mcts().get("tt_cleanup_frequency", 500)),
-        draw_penalty=float(cfg.mcts().get("draw_penalty", -0.1)),
+    mcfg_dict = dict(cfg.mcts())
+    mcfg_dict.update(
+        {
+            "num_simulations": num_sims,
+            "selection_jitter": float(cfg.selfplay().get("selection_jitter", 0.0)),
+            "batch_size": batch_size,
+            "tt_cleanup_frequency": int(cfg.mcts().get("tt_cleanup_frequency", 500)),
+        }
     )
+    mcfg = MCTSConfig.from_dict(mcfg_dict)
     
     # Load models
     model_a = PolicyValueNet.from_config(cfg.model()).to(device)

--- a/azchess/cli_play.py
+++ b/azchess/cli_play.py
@@ -39,7 +39,16 @@ def main():
             model.load_state_dict(state["model_ema"])
         else:
             model.load_state_dict(state["model"])
-    mcts = MCTS(model, MCTSConfig(num_simulations=args.sims, cpuct=cfg.selfplay().get("cpuct", 1.5), dirichlet_alpha=0.3, dirichlet_frac=0.0), device=device)
+    mcfg_dict = dict(cfg.mcts())
+    mcfg_dict.update(
+        {
+            "num_simulations": args.sims,
+            "cpuct": cfg.selfplay().get("cpuct", mcfg_dict.get("cpuct", 1.5)),
+            "dirichlet_frac": 0.0,
+            "tt_cleanup_frequency": int(cfg.mcts().get("tt_cleanup_frequency", 500)),
+        }
+    )
+    mcts = MCTS(model, MCTSConfig.from_dict(mcfg_dict), device=device)
 
     board = chess.Board()
     print("Play vs engine. Enter moves in UCI (e.g., e2e4, e7e8q). Type 'quit' to exit.")

--- a/azchess/selfplay/external_engine_worker.py
+++ b/azchess/selfplay/external_engine_worker.py
@@ -48,16 +48,21 @@ class ExternalEngineSelfPlay:
         # Load Matrix0 model
         self.matrix0_model = PolicyValueNet.from_config(config.model()).to(self.device)
         sp_cfg = config.selfplay()
+        mcfg_dict = dict(config.mcts())
+        mcfg_dict.update(
+            {
+                "num_simulations": int(sp_cfg.get("num_simulations", mcfg_dict.get("num_simulations", 200))),
+                "cpuct": float(sp_cfg.get("cpuct", mcfg_dict.get("cpuct", 1.5))),
+                "dirichlet_alpha": float(sp_cfg.get("dirichlet_alpha", mcfg_dict.get("dirichlet_alpha", 0.3))),
+                "dirichlet_frac": float(sp_cfg.get("dirichlet_frac", mcfg_dict.get("dirichlet_frac", 0.25))),
+                "tt_capacity": int(sp_cfg.get("tt_capacity", mcfg_dict.get("tt_capacity", 200000))),
+                "selection_jitter": float(sp_cfg.get("selection_jitter", mcfg_dict.get("selection_jitter", 0.0))),
+                "tt_cleanup_frequency": int(config.mcts().get("tt_cleanup_frequency", 500)),
+            }
+        )
         self.matrix0_mcts = MCTS(
             self.matrix0_model,
-            MCTSConfig(
-                num_simulations=int(sp_cfg.get("num_simulations", 200)),
-                cpuct=float(sp_cfg.get("cpuct", 1.5)),
-                dirichlet_alpha=float(sp_cfg.get("dirichlet_alpha", 0.3)),
-                dirichlet_frac=float(sp_cfg.get("dirichlet_frac", 0.25)),
-                tt_capacity=int(sp_cfg.get("tt_capacity", 200000)),
-                selection_jitter=float(sp_cfg.get("selection_jitter", 0.0)),
-            ),
+            MCTSConfig.from_dict(mcfg_dict),
             self.device,
         )
         

--- a/azchess/tools/bench_mcts.py
+++ b/azchess/tools/bench_mcts.py
@@ -54,7 +54,16 @@ def bench_mcts(cfg_path: str, sims: int, boards: int, shared: bool) -> None:
         except Exception:
             pass
 
-    mcts = MCTS(model, MCTSConfig(num_simulations=sims, batch_size=32, cpuct=float(cfg.selfplay().get('cpuct', 2.5))), device, inference_backend=backend)
+    mcfg_dict = dict(cfg.mcts())
+    mcfg_dict.update(
+        {
+            "num_simulations": sims,
+            "batch_size": 32,
+            "cpuct": float(cfg.selfplay().get('cpuct', mcfg_dict.get('cpuct', 2.5))),
+            "tt_cleanup_frequency": int(cfg.mcts().get("tt_cleanup_frequency", 500)),
+        }
+    )
+    mcts = MCTS(model, MCTSConfig.from_dict(mcfg_dict), device, inference_backend=backend)
 
     # Generate boards
     bs = [random_board() for _ in range(boards)]

--- a/azchess/tools/run_match.py
+++ b/azchess/tools/run_match.py
@@ -88,15 +88,19 @@ def main():
         model.load_state_dict(state.get("model_ema", state.get("model", {})))
     model = model.to(device)
     e = cfg.eval()
-    mcfg = MCTSConfig(
-        num_simulations=int(e.get("num_simulations", 200)),
-        cpuct=float(e.get("cpuct", 1.5)),
-        dirichlet_alpha=float(e.get("dirichlet_alpha", 0.3)),
-        dirichlet_frac=0.0,
-        tt_capacity=int(e.get("tt_capacity", 200000)) if "tt_capacity" in e else 200000,
-        selection_jitter=0.0,
+    mcfg_dict = dict(cfg.mcts())
+    mcfg_dict.update(
+        {
+            "num_simulations": int(e.get("num_simulations", mcfg_dict.get("num_simulations", 200))),
+            "cpuct": float(e.get("cpuct", mcfg_dict.get("cpuct", 1.5))),
+            "dirichlet_alpha": float(e.get("dirichlet_alpha", mcfg_dict.get("dirichlet_alpha", 0.3))),
+            "dirichlet_frac": 0.0,
+            "tt_capacity": int(e.get("tt_capacity", mcfg_dict.get("tt_capacity", 200000))),
+            "selection_jitter": 0.0,
+            "tt_cleanup_frequency": int(cfg.mcts().get("tt_cleanup_frequency", 500)),
+        }
     )
-    mcts = MCTS(model, mcfg, device)
+    mcts = MCTS(model, MCTSConfig.from_dict(mcfg_dict), device)
 
     # Stockfish
     import chess.engine

--- a/webui/server.py
+++ b/webui/server.py
@@ -114,15 +114,19 @@ def _load_matrix0(cfg_path: str = "config.yaml", ckpt: Optional[str] = None, dev
         model.load_state_dict(state.get("model_ema", state.get("model", {})))
     _matrix0_model = model.to(_device)
     e = cfg.eval()
-    mcfg = MCTSConfig(
-        num_simulations=int(e.get("num_simulations", 200)),
-        cpuct=float(e.get("cpuct", 1.5)),
-        dirichlet_alpha=float(e.get("dirichlet_alpha", 0.3)),
-        dirichlet_frac=0.0,
-        tt_capacity=int(e.get("tt_capacity", 200000)) if "tt_capacity" in e else 200000,
-        selection_jitter=0.0,
+    mcfg_dict = dict(cfg.mcts())
+    mcfg_dict.update(
+        {
+            "num_simulations": int(e.get("num_simulations", mcfg_dict.get("num_simulations", 200))),
+            "cpuct": float(e.get("cpuct", mcfg_dict.get("cpuct", 1.5))),
+            "dirichlet_alpha": float(e.get("dirichlet_alpha", mcfg_dict.get("dirichlet_alpha", 0.3))),
+            "dirichlet_frac": 0.0,
+            "tt_capacity": int(e.get("tt_capacity", mcfg_dict.get("tt_capacity", 200000))),
+            "selection_jitter": 0.0,
+            "tt_cleanup_frequency": int(cfg.mcts().get("tt_cleanup_frequency", 500)),
+        }
     )
-    _matrix0_mcts = MCTS(_matrix0_model, mcfg, _device)
+    _matrix0_mcts = MCTS(_matrix0_model, MCTSConfig.from_dict(mcfg_dict), _device)
 
 
 def _load_stockfish() -> Optional["chess.engine.SimpleEngine"]:


### PR DESCRIPTION
## Summary
- build MCTSConfig via `from_dict(cfg.mcts())` in arena, self-play, web UI and tooling scripts
- apply local overrides (num_simulations, batch size, etc.) by mutating the config dict before instantiation
- ensure all scripts use shared MCTS defaults for consistent behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5fcd470408323a7ec969fbc63ed83