### PR TITLE
feat(webui): add websocket updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,14 @@ python -m azchess.arena --ckpt_a checkpoints/enhanced_best.pt --ckpt_b checkpoin
 # Play against trained model
 python -m azchess.cli_play
 
-# Web interface (eval mode)
+# Web interface with real-time updates
 uvicorn webui.server:app --host 127.0.0.1 --port 8000
 ```
+
+Launch the server and open <http://127.0.0.1:8000> in your browser. The
+frontend connects to `ws://localhost:8000/ws/{game_id}` for live FEN,
+evaluation and result updates. Multiple concurrent games can be managed via
+tabs at the top of the page.
 
 ### **5. Analyze Self-Play Games**
 ```bash

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,19 @@
+# Matrix0 WebUI
+
+The WebUI provides a browser interface for playing and evaluating games against
+Matrix0 and Stockfish.
+
+## Running
+
+```
+uvicorn webui.server:app --host 127.0.0.1 --port 8000
+```
+
+Open <http://127.0.0.1:8000> in your browser. Each new game uses a dedicated
+WebSocket (`/ws/{game_id}`) that streams the current FEN, game result and
+evaluation data. The REST endpoints (`/move`, `/engine-move`, `/eval`) remain
+available for fallbacks but all updates are also pushed over the socket.
+
+Multiple games can be played simultaneously. Every game opened creates a new
+tab; switching tabs restores the board, move list and evaluation chart for that
+game.

--- a/webui/static/app.js
+++ b/webui/static/app.js
@@ -1,25 +1,33 @@
-let gameId = null;
+let games = {}; // gameId -> { chess, evalData, socket, log }
+let currentGameId = null;
 let board = null;
-let chess = new Chess();
-let evalData = { ply: [], matrix0: [], stockfish: [] };
+let chess = null;
+let evalData = null;
 let evalChart = null;
 
-function log(msg) {
-  const el = document.getElementById('log');
-  el.textContent = `[${new Date().toLocaleTimeString()}] ${msg}\n` + el.textContent;
+function log(gid, msg) {
+  const g = games[gid];
+  if (!g) return;
+  if (!g.log) g.log = [];
+  g.log.unshift(`[${new Date().toLocaleTimeString()}] ${msg}`);
+  if (gid === currentGameId) {
+    document.getElementById('log').textContent = g.log.join('\n');
+  }
 }
 
 function updateState(fen, turn, finished, result) {
+  if (!chess) return;
   chess.load(fen);
   document.getElementById('fen').textContent = fen;
   document.getElementById('turn').textContent = turn;
-  if (finished) log(`Game over: ${result}`);
+  if (finished) log(currentGameId, `Game over: ${result}`);
   board.set({ fen, turnColor: (turn === 'w' ? 'white' : 'black') });
   renderMoves();
   renderChart();
 }
 
 function renderMoves() {
+  if (!chess) return;
   const el = document.getElementById('movelist');
   const hist = chess.history({ verbose: true });
   const out = [];
@@ -42,68 +50,126 @@ async function api(path, body) {
   return await res.json();
 }
 
+function addTab(gid) {
+  let tabs = document.getElementById('tabs');
+  if (!tabs) {
+    tabs = document.createElement('div');
+    tabs.id = 'tabs';
+    tabs.style.display = 'flex';
+    tabs.style.gap = '8px';
+    const header = document.querySelector('header');
+    header.appendChild(tabs);
+  }
+  const btn = document.createElement('button');
+  btn.textContent = gid;
+  btn.addEventListener('click', () => setActiveGame(gid));
+  tabs.appendChild(btn);
+}
+
+function setActiveGame(gid) {
+  currentGameId = gid;
+  const g = games[gid];
+  chess = g.chess;
+  evalData = g.evalData;
+  document.getElementById('gid').textContent = gid;
+  const finished = g.chess.game_over();
+  let result = null;
+  if (finished) {
+    if (g.chess.in_draw()) result = '1/2-1/2';
+    else result = (g.chess.turn() === 'w') ? '0-1' : '1-0';
+  }
+  updateState(g.chess.fen(), g.chess.turn(), finished, result);
+  if (g.log) document.getElementById('log').textContent = g.log.join('\n');
+  document.getElementById('mval').textContent = (g.lastMat === undefined || g.lastMat === null ? '—' : g.lastMat.toFixed(3));
+  document.getElementById('scpf').textContent = (g.lastCp === undefined || g.lastCp === null ? '—' : g.lastCp);
+}
+
+function onMessage(gid, ev) {
+  const msg = JSON.parse(ev.data);
+  const g = games[gid];
+  if (!g) return;
+  if (msg.type === 'state') {
+    g.chess.load(msg.fen);
+    if (gid === currentGameId) {
+      updateState(msg.fen, msg.turn, msg.game_over, msg.result);
+    }
+  } else if (msg.type === 'eval') {
+    const ply = g.chess.history().length;
+    g.evalData.ply.push(ply);
+    g.evalData.matrix0.push(msg.matrix0_value);
+    g.evalData.stockfish.push(msg.stockfish_cp !== null ? msg.stockfish_cp / 100.0 : null);
+    g.lastMat = msg.matrix0_value;
+    g.lastCp = msg.stockfish_cp;
+    if (gid === currentGameId) {
+      renderChart();
+      document.getElementById('mval').textContent = (g.lastMat === null ? '—' : g.lastMat.toFixed(3));
+      document.getElementById('scpf').textContent = (g.lastCp === null ? '—' : g.lastCp);
+    }
+  }
+}
+
 async function newGame() {
   const white = document.getElementById('white').value;
   const black = document.getElementById('black').value;
   const tc = parseInt(document.getElementById('tc').value || '100', 10);
   const out = await api('/new', { white, black, engine_tc_ms: tc });
-  gameId = out.game_id;
-  document.getElementById('gid').textContent = gameId;
+  const gid = out.game_id;
+  games[gid] = {
+    chess: new Chess(out.fen),
+    evalData: { ply: [], matrix0: [], stockfish: [] },
+    socket: null,
+    log: [],
+  };
   document.getElementById('tclabel').textContent = tc;
-  log(`New game ${gameId}: ${white} vs ${black}`);
-  evalData = { ply: [], matrix0: [], stockfish: [] };
-  updateState(out.fen, out.turn, false, null);
+  addTab(gid);
+  setActiveGame(gid);
+  log(gid, `New game ${gid}: ${white} vs ${black}`);
+  const proto = (location.protocol === 'https:' ? 'wss' : 'ws');
+  const ws = new WebSocket(`${proto}://${location.host}/ws/${gid}`);
+  ws.onmessage = (ev) => onMessage(gid, ev);
+  games[gid].socket = ws;
   loadAnalytics();
 }
 
 async function pushMove(uci) {
-  const out = await api('/move', { game_id: gameId, uci });
-  updateState(out.fen, out.turn, out.game_over, out.result);
+  const gid = currentGameId;
+  if (!gid) return;
+  await api('/move', { game_id: gid, uci });
+  log(gid, `Human plays ${uci}`);
 }
 
 async function engineMove() {
-  if (!gameId) return;
+  if (!currentGameId) return;
   const turn = chess.turn();
   const color = (turn === 'w' ? 'white' : 'black');
   const engine = document.getElementById(color).value; // who plays this color
-  const out = await api('/engine-move', { game_id: gameId, engine });
-  log(`${engine} plays ${out.uci}`);
-  updateState(out.fen, out.turn, out.game_over, out.result);
-  // collect eval snapshot
+  const out = await api('/engine-move', { game_id: currentGameId, engine });
+  log(currentGameId, `${engine} plays ${out.uci}`);
   try { await evalPos(); } catch {}
 }
 
 async function evalPos() {
-  if (!gameId) return;
-  const out = await api('/eval', { game_id: gameId, include_stockfish: true });
-  document.getElementById('mval').textContent = (out.matrix0_value === null ? '—' : out.matrix0_value.toFixed(3));
-  document.getElementById('scpf').textContent = (out.stockfish_cp === null ? '—' : out.stockfish_cp);
-  // push evals for chart
-  const ply = chess.history().length;
-  evalData.ply.push(ply);
-  evalData.matrix0.push(out.matrix0_value);
-  evalData.stockfish.push(out.stockfish_cp !== null ? out.stockfish_cp / 100.0 : null);
-  renderChart();
+  if (!currentGameId) return;
+  await api('/eval', { game_id: currentGameId, include_stockfish: true });
 }
 
 function initBoard() {
+  const startFen = new Chess().fen();
   board = Chessground(document.getElementById('board'), {
-    fen: chess.fen(),
+    fen: startFen,
     orientation: 'white',
     movable: {
       free: false,
       color: () => 'both',
       events: {
         after: async (orig, dest, meta) => {
-          if (!gameId) return;
-          // promotion
-          let promo = '';
+          if (!currentGameId) return;
           const move = { from: orig, to: dest, promotion: (meta.promotion || 'q') };
           const uci = move.from + move.to + (move.promotion ? move.promotion : '');
           try {
             await pushMove(uci);
           } catch (e) {
-            log('Illegal move');
+            log(currentGameId, 'Illegal move');
             board.set({ fen: chess.fen() });
           }
           try { await evalPos(); } catch {}
@@ -114,6 +180,7 @@ function initBoard() {
 }
 
 function renderChart() {
+  if (!evalData) return;
   const ctx = document.getElementById('evalChart').getContext('2d');
   const data = {
     labels: evalData.ply,


### PR DESCRIPTION
## Summary
- stream game state and evaluations over `/ws/{game_id}` websockets
- broadcast moves and evals to connected clients
- enhance WebUI with persistent sockets, auto-refreshing charts, and game tabs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61fa7d8f48323b5ba2fc5e1f8307a