### PR TITLE
Add piece-type biased attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Matrix0 is an efficient, AlphaZero-style chess engine designed specifically for 
 - **Backbone**: ResNet-14 with 160 channels (~22M parameters)
 - **Heads**: Policy (4672 actions), Value (scalar), SSL (piece prediction)
 - **Features**: Squeeze-and-Excitation blocks, chess-specific attention
+  with optional piece-type bias
 
 ### **MCTS Engine**
 - **Search**: Monte Carlo Tree Search with transposition tables
@@ -136,7 +137,7 @@ When run without arguments the script behaves as before, analyzing games in
 
 The main configuration is in `config.yaml` with sections for:
 
-- **Model**: Architecture parameters (channels, blocks, features)
+- **Model**: Architecture parameters (channels, blocks, features, `piece_type_bias`)
 - **MCTS**: Search parameters (simulations, cpuct, dirichlet)
 - **Self-play**: Worker count, game settings, termination criteria
 - **Training**: Batch size, learning rate, optimization settings

--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,7 @@ model:
   attention: true  # Enable attention mechanisms
   attention_heads: 8
   attention_unmasked_mix: 0.2  # Blend some unmasked attention for knight/tactics
+  piece_type_bias: true  # Bias attention by piece type
   chess_features: true  # Enable chess-specific features
   self_supervised: true  # Enable self-supervised learning
   piece_square_tables: true  # Enable piece-square table features


### PR DESCRIPTION
## Summary
- Introduce optional piece-type bias embeddings in `ChessAttention`
- Wire board planes into attention and allow toggling via `piece_type_bias` in model config
- Document piece-type bias option in README and default config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a61fa06d9c8323bd6b69a140d34770