### PR TITLE
Restrict SSL tasks to piece and update docs

### DIFF
--- a/azchess/model/resnet.py
+++ b/azchess/model/resnet.py
@@ -249,7 +249,7 @@ class NetConfig:
     aux_policy_move_type: bool = False # Auxiliary move-type head
     enable_visual: bool = False # Enable visual encoder
     visual_encoder_channels: int = 64 # Channels for visual encoder
-    ssl_tasks: List[str] = field(default_factory=lambda: ["piece"]) # Basic piece recognition only
+    ssl_tasks: List[str] = field(default_factory=lambda: ["piece"]) # Basic piece recognition only (other tasks ignored)
     ssl_curriculum: bool = False # Progressive difficulty
     ssrl_tasks: List[str] = field(default_factory=list) # No SSRL tasks by default
     enable_llm_tutor: bool = False # LLM integration
@@ -307,7 +307,7 @@ class PolicyValueNet(nn.Module):
         # Self-supervised learning head (if enabled)
         if cfg.self_supervised:
             # Enhanced SSL with multiple tasks support
-            ssl_tasks = getattr(cfg, 'ssl_tasks', ['piece'])
+            ssl_tasks = getattr(cfg, 'ssl_tasks', ['piece'])  # Only 'piece' task currently implemented
             if 'piece' in ssl_tasks:
                 self.ssl_piece_head = nn.Sequential(
                     nn.Conv2d(C, C // 2, kernel_size=1, bias=False),
@@ -660,7 +660,11 @@ class PolicyValueNet(nn.Module):
         return loss
     
     def get_enhanced_ssl_loss(self, x: torch.Tensor, targets: Dict[str, torch.Tensor]) -> torch.Tensor:
-        """Compute enhanced SSL loss for multiple tasks."""
+        """Compute SSL loss for supported tasks.
+
+        Currently only the 'piece' task is implemented; additional tasks
+        will be added in future updates.
+        """
         total_loss = 0.0
         
         # Piece prediction task

--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,7 @@ model:
   aux_policy_move_type: true       # Auxiliary move-type prediction
   ssl_curriculum: true             # Self-supervised learning curriculum
   self_supervised: true              # Enable SSL
-  ssl_tasks: ["piece", "threat", "pin", "fork", "control"]  # SSL tasks (32M model)
+  ssl_tasks: ["piece"]  # SSL tasks (only piece task currently supported)
   ssrl_tasks: ["position", "material", "rotation"]  # SSRL tasks (32M model)
 
 selfplay:

--- a/create_v2_checkpoint.py
+++ b/create_v2_checkpoint.py
@@ -62,7 +62,7 @@ def create_v2_checkpoint():
             aux_policy_move_type=model_cfg.get('aux_policy_move_type', True),
             enable_visual=model_cfg.get('enable_visual', False),
             visual_encoder_channels=model_cfg.get('visual_encoder_channels', 64),
-            ssl_tasks=model_cfg.get('ssl_tasks', ['piece']),
+            ssl_tasks=model_cfg.get('ssl_tasks', ['piece']),  # only piece SSL task currently supported
             ssl_curriculum=model_cfg.get('ssl_curriculum', True),
             ssrl_tasks=model_cfg.get('ssrl_tasks', ['position', 'material', 'rotation'])
         )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ model:
   policy_factor_rank: 128          # Factorized policy head
   ssl_curriculum: true             # Self-supervised learning curriculum
   self_supervised: true            # Enable SSL
-  ssl_tasks: ["piece", "threat", "pin", "fork", "control"]  # SSL tasks
+  ssl_tasks: ["piece"]  # SSL tasks (only piece task currently supported)
 ```
 
 ## 2. Key Configuration Sections
@@ -53,7 +53,7 @@ model:
 - `policy_factor_rank`: Factorized policy head rank (default: `128`)
 - `ssl_curriculum`: Enable SSL progressive difficulty (default: `true`)
 - `self_supervised`: Enable self-supervised learning (default: `true`)
-- `ssl_tasks`: List of SSL tasks to train (`["piece", "threat", "pin", "fork", "control"]`)
+- `ssl_tasks`: List of SSL tasks to train (currently only `["piece"]` is supported)
 
 ### `selfplay` - Self-Play Data Generation
 - `num_workers`: Number of parallel self-play workers (default: `6`)
@@ -167,7 +167,7 @@ The system uses dataclasses for type-safe configuration:
 ```yaml
 model:
   ssl_curriculum: true             # Progressive difficulty
-  ssl_tasks: ["piece", "threat", "pin", "fork", "control"]
+  ssl_tasks: ["piece"]
   ssl_warmup_steps: 200            # Gradual SSL introduction
 
 training:

--- a/docs/model_v2.md
+++ b/docs/model_v2.md
@@ -175,7 +175,7 @@ model:
   cross_modal_attention: true     # enable cross-modal attention
   
   # Enhanced SSL/SSRL
-  ssl_tasks: ["piece", "relationship", "threat", "pawn_structure", "king_safety"]
+  ssl_tasks: ["piece"]  # only piece recognition supported currently
   ssl_curriculum: true            # enable progressive difficulty
   ssrl_tasks: ["masked_prediction", "contrastive", "rotation_invariance"]
   
@@ -187,12 +187,8 @@ model:
 training:
   # SSL enhancements
   ssl_label_smoothing: 0.05
-  ssl_task_weights:              # weights for multi-task SSL
+  ssl_task_weights:              # weights for supported SSL tasks
     piece: 1.0
-    relationship: 0.8
-    threat: 0.9
-    pawn_structure: 0.7
-    king_safety: 0.8
   
   # SSRL configuration
   ssrl_loss_weight: 0.3
@@ -388,7 +384,7 @@ model:
   policy_factor_rank: 0
   enable_visual: false
   enable_llm_tutor: false
-  ssl_tasks: ["piece"]  # basic SSL only
+  ssl_tasks: ["piece"]  # basic SSL only (currently the only supported task)
 ```
 
 ### Gradual Fallback Options
@@ -486,7 +482,7 @@ model:
   aux_policy_move_type: true
   enable_visual: true
   enable_llm_tutor: true
-  ssl_tasks: ["piece", "relationship", "threat", "pawn_structure", "king_safety"]
+  ssl_tasks: ["piece"]
   ssl_curriculum: true
   ssrl_tasks: ["masked_prediction", "contrastive", "rotation_invariance"]
 
@@ -494,10 +490,6 @@ training:
   ssl_label_smoothing: 0.05
   ssl_task_weights:
     piece: 1.0
-    relationship: 0.8
-    threat: 0.9
-    pawn_structure: 0.7
-    king_safety: 0.8
   ssrl_loss_weight: 0.3
   visual_loss_weight: 0.2
   llm_guidance_weight: 0.1


### PR DESCRIPTION
## Summary
- Limit `ssl_tasks` to the supported `"piece"` task
- Clarify in code and docs that only the piece SSL head exists for now
- Adjust training docs to remove references to unsupported SSL tasks

## Testing
- `pytest` *(fails: AttributeError: 'DummyModel' object has no attribute 'num_threads')*

------
https://chatgpt.com/codex/tasks/task_e_68a90740076883238af4e8d572d2297d