### PR TITLE
Parameterize plane count for shape validation

### DIFF
--- a/azchess/orchestrator.py
+++ b/azchess/orchestrator.py
@@ -633,14 +633,20 @@ def orchestrate(cfg_path: str, games_override: int | None = None, eval_games_ove
                 attempt += 1
         # Post self-play: compact data, validate/quarantine if requested
         logger.info("Compacting self-play data into replay buffer")
-        dm = DataManager(base_dir=cfg.get("data_dir", "data"))
+        dm = DataManager(
+            base_dir=cfg.get("data_dir", "data"),
+            expected_planes=cfg.model().get("planes", 19),
+        )
         try:
             dm.compact_selfplay_to_replay()
         except Exception as e:
             logger.warning(f"Data compaction failed: {e}")
 
         # Re-initialize DataManager to ensure it sees the new data
-        dm = DataManager(base_dir=cfg.get("data_dir", "data"))
+        dm = DataManager(
+            base_dir=cfg.get("data_dir", "data"),
+            expected_planes=cfg.model().get("planes", 19),
+        )
 
         if run_doctor_fix:
             try:
@@ -680,7 +686,10 @@ def orchestrate(cfg_path: str, games_override: int | None = None, eval_games_ove
 
         # Ensure we have usable data before training
         try:
-            stats = DataManager(base_dir=cfg.get("data_dir", "data")).get_stats()
+            stats = DataManager(
+                base_dir=cfg.get("data_dir", "data"),
+                expected_planes=cfg.model().get("planes", 19),
+            ).get_stats()
             if int(stats.total_samples) <= 0:
                 logger.warning("No training data available after ingestion; skipping training and evaluation.")
                 return

--- a/azchess/selfplay/internal.py
+++ b/azchess/selfplay/internal.py
@@ -244,7 +244,10 @@ def selfplay_worker(proc_id: int, cfg_dict: dict, ckpt_path: str | None, games: 
         device=device,
         inference_backend=infer_backend,
     )
-    data_manager = DataManager(base_dir=cfg_dict.get("data_dir", "data"))
+    data_manager = DataManager(
+        base_dir=cfg_dict.get("data_dir", "data"),
+        expected_planes=cfg_dict.get("model", {}).get("planes", 19),
+    )
 
     for g in range(games):
         board = get_opening_position()

--- a/azchess/training/train.py
+++ b/azchess/training/train.py
@@ -550,7 +550,10 @@ def train_comprehensive(
         logger.info(f"Applied warmup LR: {learning_rate * warmup_factor:.6f}")
 
     # Setup data using DataManager
-    data_manager = DataManager(base_dir=cfg.get("data_dir", "data"))
+    data_manager = DataManager(
+        base_dir=cfg.get("data_dir", "data"),
+        expected_planes=cfg.model().get("planes", 19),
+    )
     data_stats = data_manager.get_stats()
     external_stats = data_manager.get_external_data_stats()
     


### PR DESCRIPTION
## Summary
- accept configurable plane count in data loaders
- use provided plane count when validating state tensor shapes
- pass Config.model()["planes"] when constructing DataManager instances

## Testing
- `pytest -q` *(fails: AttributeError: 'DummyModel' object has no attribute 'num_threads')*

------
https://chatgpt.com/codex/tasks/task_e_68a907c94c848323a5a3089236d10630