### PR TITLE
Add shared memory cleanup utilities

### DIFF
--- a/azchess/orchestrator.py
+++ b/azchess/orchestrator.py
@@ -14,7 +14,11 @@ from rich.progress import Progress, BarColumn, TimeElapsedColumn, TimeRemainingC
 from .config import Config
 from .logging_utils import setup_logging
 from .selfplay.internal import selfplay_worker, math_div_ceil
-from .selfplay.inference import run_inference_server, setup_shared_memory_for_worker
+from .selfplay.inference import (
+    run_inference_server,
+    setup_shared_memory_for_worker,
+    cleanup_shared_memory,
+)
 from .config import select_device
 from azchess.training.train import train_from_config as train_main
 from .arena import play_match
@@ -617,6 +621,8 @@ def orchestrate(cfg_path: str, games_override: int | None = None, eval_games_ove
                         infer_proc.join(timeout=5)
                     except Exception:
                         pass
+                if shared_memory_resources:
+                    cleanup_shared_memory(shared_memory_resources)
             return stats, done
 
         # Retry loop for self-play


### PR DESCRIPTION
## Summary
- add `cleanup_shared_memory` helper to detach tensors, close events, and remove shared memory references
- invoke shared memory cleanup after joining self-play workers and inference server

## Testing
- `pytest -q` *(fails: AttributeError: 'DummyModel' object has no attribute 'num_threads')*

------
https://chatgpt.com/codex/tasks/task_e_68a907813990832383722f023a2078a8