### PR TITLE
Scale policy_fc2 weights in factorized head

### DIFF
--- a/azchess/model/resnet.py
+++ b/azchess/model/resnet.py
@@ -486,6 +486,8 @@ class PolicyValueNet(nn.Module):
             self.policy_conv_out.weight.data *= 0.05  # Further reduced from 0.1 to 0.05
             if self.policy_fc is not None:
                 self.policy_fc.weight.data *= 0.3  # Further reduced from 0.5 to 0.3
+            elif self.policy_fc2 is not None:
+                self.policy_fc2.weight.data *= 0.3  # Apply same scaling in factorized case
             logger.info("Policy head weights scaled down for numerical stability")
             
         # CRITICAL: Initialize normalization layers for stability


### PR DESCRIPTION
## Summary
- Scale `policy_fc2.weight` by `0.3` when using the factorized policy head to match the conservative initialization of the non-factorized branch

## Testing
- `pytest` *(fails: tests/test_mcts_no_psutil.py::test_mcts_runs_without_psutil)*

------
https://chatgpt.com/codex/tasks/task_e_68a907e12e8c83238b6ebfaeffaa9315