### PR TITLE
Add shared memory cleanup utilities and fix MCTS constructor

### DIFF
--- a/azchess/mcts.py
+++ b/azchess/mcts.py
@@ -290,25 +290,27 @@ class Node:
 
 
 class MCTS:
-    def __init__(self, cfg: MCTSConfig, model, device: str = "cpu", inference_backend=None, num_threads: int = None):
+    def __init__(
+        self,
+        cfg: MCTSConfig,
+        model=None,
+        device: str = "cpu",
+        inference_backend=None,
+        num_threads: int = None,
+    ):
+        if isinstance(cfg, torch.nn.Module) or cfg is None:
+            cfg, model = model, cfg
+
         self.cfg = cfg
         self.device = device
         self.model = model
         self.inference_backend = inference_backend
-        self._enc = MoveEncoder()
+
         self._tt = {}
         self._tt_lock = threading.Lock()
         self._tt_cleanup_counter = 0
         self._last_cleanup_time = time.time()
-        
-        # FIXED: Proper ThreadPool initialization with deadlock prevention
-        self.num_threads = cfg.num_threads
-        if self.num_threads > 1:
-            self.thread_pool = ThreadPool(self.num_threads)
-            logger.info(f"MCTS initialized with {self.num_threads} threads for parallel simulation")
-        else:
-            self.thread_pool = None
-            logger.info("MCTS running in single-threaded mode")
+
         self.tt = OrderedDict()  # Transposition table
         self.nn_cache = LRUCache(10000)  # Neural network cache
         self.simulations_run = 0
@@ -319,15 +321,26 @@ class MCTS:
         self._memory_cleanup_threshold = 85.0
         self.tt_hits = 0
         self.tt_misses = 0
-        
+
         # Move encoder cache
-        self._enc: Optional[MoveEncoder] = MoveEncoder() if bool(cfg.encoder_cache) else None
+        self._enc: Optional[MoveEncoder] = (
+            MoveEncoder() if bool(cfg.encoder_cache) else None
+        )
         self._last_cleanup_wall: float = time.time()
 
-        # Use config num_threads if not specified, fallback to 1
-        self.num_threads = num_threads if num_threads is not None else getattr(cfg, 'num_threads', 1)
+        # Configure threading
+        self.num_threads = (
+            num_threads if num_threads is not None else getattr(cfg, "num_threads", 1)
+        )
         if self.num_threads > 1:
             self.thread_pool = ThreadPool(self.num_threads)
+            logger.info(
+                f"MCTS initialized with {self.num_threads} threads for parallel simulation"
+            )
+        else:
+            self.thread_pool = None
+            logger.info("MCTS running in single-threaded mode")
+
         self.lock = threading.Lock()
 
     @torch.no_grad()

--- a/azchess/orchestrator.py
+++ b/azchess/orchestrator.py
@@ -14,7 +14,11 @@ from rich.progress import Progress, BarColumn, TimeElapsedColumn, TimeRemainingC
 from .config import Config
 from .logging_utils import setup_logging
 from .selfplay.internal import selfplay_worker, math_div_ceil
-from .selfplay.inference import run_inference_server, setup_shared_memory_for_worker
+from .selfplay.inference import (
+    run_inference_server,
+    setup_shared_memory_for_worker,
+    cleanup_shared_memory,
+)
 from .config import select_device
 from azchess.training.train import train_from_config as train_main
 from .arena import play_match
@@ -617,6 +621,8 @@ def orchestrate(cfg_path: str, games_override: int | None = None, eval_games_ove
                         infer_proc.join(timeout=5)
                     except Exception:
                         pass
+                if shared_memory_resources:
+                    cleanup_shared_memory(shared_memory_resources)
             return stats, done
 
         # Retry loop for self-play


### PR DESCRIPTION
## Summary
- add `cleanup_shared_memory` helper to detach tensors, close events, and remove shared memory references
- invoke shared memory cleanup after joining self-play workers and inference server
- allow `MCTS` to accept model/config arguments in either order and streamline thread pool setup

## Testing
- `pytest tests/test_mcts_no_psutil.py::test_mcts_runs_without_psutil -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a907813990832383722f023a2078a8