### PR TITLE
refactor: use shared logging setup

### DIFF
--- a/azchess/selfplay/internal.py
+++ b/azchess/selfplay/internal.py
@@ -22,13 +22,13 @@ from .inference import InferenceClient
 from ..encoding import encode_board, move_to_index
 import chess.polyglot
 from ..draw import should_adjudicate_draw
+from azchess.logging_utils import setup_logging
 
 
 def math_div_ceil(a: int, b: int) -> int:
     """Integer division with ceiling."""
     return (a + b - 1) // b
-
-logger = logging.getLogger(__name__)
+logger = setup_logging(level=logging.INFO)
 OPENING_BOOK: List[chess.Board] = []
 
 def load_opening_book(pgn_path: str):
@@ -94,8 +94,7 @@ def selfplay_worker(proc_id: int, cfg_dict: dict, ckpt_path: str | None, games: 
     # Set up logging for this worker
     lvl_name = os.environ.get('MATRIX0_WORKER_LOG_LEVEL', 'INFO').upper()  # Changed to INFO for debugging
     level = getattr(logging, lvl_name, logging.INFO)
-    logging.basicConfig(level=level, format='%(asctime)s - %(levelname)s - %(message)s')
-    logger = logging.getLogger(f"selfplay_worker_{proc_id}")
+    logger = setup_logging(level=level, name=f"selfplay_worker_{proc_id}")
 
     logger.info(f"Worker {proc_id} starting with PID {os.getpid()}")
     logger.info(f"Worker {proc_id} config: games={games}, device={select_device(cfg_dict.get('device', 'auto'))}")

--- a/azchess/tools/enhanced_eval.py
+++ b/azchess/tools/enhanced_eval.py
@@ -33,6 +33,7 @@ from ..model import PolicyValueNet
 from ..mcts import MCTS, MCTSConfig
 from ..elo import EloBook, update_elo
 from ..draw import should_adjudicate_draw
+from ..logging_utils import setup_logging
 
 
 class EnhancedEvaluator:
@@ -78,23 +79,13 @@ class EnhancedEvaluator:
         
     def _setup_logging(self):
         """Setup comprehensive logging for debugging."""
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            handlers=[
-                logging.FileHandler('data/eval_debug.log'),
-                logging.StreamHandler()
-            ]
-        )
-        self.logger = logging.getLogger(__name__)
-        
-        # Filter out the noisy "Policy too uniform" debug messages from MCTS
+        self.logger = setup_logging(level=logging.INFO)
+
         class PolicyUniformFilter(logging.Filter):
             def filter(self, record):
-                return not ("Policy too uniform" in record.getMessage())
-        
-        # Apply filter to all handlers
-        for handler in logging.root.handlers:
+                return "Policy too uniform" not in record.getMessage()
+
+        for handler in self.logger.handlers:
             handler.addFilter(PolicyUniformFilter())
         
     def _load_models(self):

--- a/azchess/tools/model_info.py
+++ b/azchess/tools/model_info.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import argparse
 import logging
-import sys
 
+from azchess.logging_utils import setup_logging
 from azchess.config import Config
 from azchess.model import PolicyValueNet
 
 
-logger = logging.getLogger(__name__)
+logger = setup_logging(level=logging.INFO)
 
 
 def main():
@@ -30,6 +30,5 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
     main()
 

--- a/azchess/tools/process_lichess.py
+++ b/azchess/tools/process_lichess.py
@@ -24,10 +24,10 @@ import chess.pgn
 import numpy as np
 
 from azchess.encoding import encode_board, move_to_index
+from azchess.logging_utils import setup_logging
 
 # Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
+logger = setup_logging(level=logging.INFO)
 
 # --- Configuration ---
 LICHESS_DB_URL = "https://database.lichess.org/standard/"

--- a/azchess/training/train.py
+++ b/azchess/training/train.py
@@ -31,10 +31,10 @@ from azchess.config import Config, select_device
 from azchess.model import PolicyValueNet
 from azchess.data_manager import DataManager
 from azchess.encoding import encode_board, move_to_index, POLICY_SHAPE
+from azchess.logging_utils import setup_logging
 
 # Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
+logger = setup_logging(level=logging.INFO)
 
 class EMA:
     """Exponential Moving Average for model weights."""

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -16,12 +16,16 @@ from typing import Dict, List, Any, Optional, Tuple
 import json
 import yaml
 
+from azchess.logging_utils import setup_logging
+
+logger = setup_logging(level=logging.INFO)
+
 try:
     import torch
     TORCH_AVAILABLE = True
 except ImportError:
     TORCH_AVAILABLE = False
-    logging.warning("PyTorch not available - Matrix0 model loading disabled")
+    logger.warning("PyTorch not available - Matrix0 model loading disabled")
 
 from benchmarks.config import ConfigManager, BenchmarkConfig, UCIEngineConfig, TestScenario
 from benchmarks.uci_bridge import EngineManager
@@ -31,12 +35,6 @@ if TORCH_AVAILABLE:
     from azchess.model.resnet import PolicyValueNet
     from azchess.config import Config
 
-# Setup logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger(__name__)
 
 
 class BenchmarkRunner:

--- a/comprehensive_data_loader.py
+++ b/comprehensive_data_loader.py
@@ -14,12 +14,13 @@ import argparse
 import logging
 from typing import Dict, Optional, List, Tuple
 
+from azchess.logging_utils import setup_logging
+
 # Add project root to path
 sys.path.append(str(Path(__file__).parent))
 
 # Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
+logger = setup_logging(level=logging.INFO)
 
 class ComprehensiveDataLoader:
     """Comprehensive data loader that combines multiple data sources."""

--- a/create_v2_checkpoint.py
+++ b/create_v2_checkpoint.py
@@ -9,6 +9,8 @@ import sys
 import torch
 import logging
 
+from azchess.logging_utils import setup_logging
+
 # Add the project root to the path
 sys.path.insert(0, '/Users/admin/Downloads/VSCode/Matrix0')
 
@@ -19,8 +21,7 @@ def create_v2_checkpoint():
     """Create a fresh V2 model checkpoint."""
 
     # Set up logging
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-    logger = logging.getLogger(__name__)
+    logger = setup_logging(level=logging.INFO)
 
     try:
         # Load configuration


### PR DESCRIPTION
## Summary
- Replace `logging.basicConfig` calls with `setup_logging` across data loaders, training scripts, tools, and self-play workers.
- Import `setup_logging` and route all logging through its returned logger instances.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a912903564832384238d99ded7267d