### PR TITLE
Remove duplicate DataManager initialization

### DIFF
--- a/azchess/data_manager.py
+++ b/azchess/data_manager.py
@@ -62,14 +62,7 @@ class DataManager:
         # Initialize database for tracking
         self.db_path = self.base_dir / "data_metadata.db"
         self._init_database()
-        
-        # Version tracking
-        self.version = "1.0.0"
-        
-        # Initialize database for tracking
-        self.db_path = self.base_dir / "data_metadata.db"
-        self._init_database()
-        
+
         # Version tracking
         self.version = "1.0.0"
         


### PR DESCRIPTION
## Summary
- Ensure DataManager's database setup executes only once by removing a redundant block assigning `db_path`, calling `_init_database`, and setting `version`.

## Testing
- `python - <<'PY'
from azchess.data_manager import DataManager
import tempfile, os
base_dir = tempfile.mkdtemp()
dm = DataManager(base_dir=base_dir)
print('db exists:', os.path.exists(os.path.join(base_dir, 'data_metadata.db')))
print('version:', dm.version)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9128e8b1c8323815dde73a002043c