### PR TITLE
refactor: centralize random board helper

### DIFF
--- a/azchess/tools/bench_mcts.py
+++ b/azchess/tools/bench_mcts.py
@@ -2,30 +2,16 @@ from __future__ import annotations
 
 import argparse
 import time
-import random
 from multiprocessing import Process, Event, Queue
 
-import numpy as np
 import chess
 import torch
 
 from ..config import Config, select_device
 from ..model import PolicyValueNet
 from ..mcts import MCTS, MCTSConfig
-from ..encoding import encode_board
 from ..selfplay.inference import run_inference_server, InferenceClient
-
-
-def random_board(max_plies: int = 40, seed: int | None = None) -> chess.Board:
-    if seed is not None:
-        random.seed(seed)
-    b = chess.Board()
-    for _ in range(random.randint(1, max_plies)):
-        if b.is_game_over():
-            break
-        mv = random.choice(list(b.legal_moves))
-        b.push(mv)
-    return b
+from ..utils.board import random_board
 
 
 def bench_mcts(cfg_path: str, sims: int, boards: int, shared: bool) -> None:

--- a/azchess/utils/__init__.py
+++ b/azchess/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for azchess."""
+
+__all__ = ["random_board"]
+
+from .board import random_board

--- a/azchess/utils/board.py
+++ b/azchess/utils/board.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import chess
+import numpy as np
+
+
+def random_board(
+    plies: int | None = None,
+    *,
+    max_plies: int = 40,
+    seed: int | None = None,
+) -> chess.Board:
+    """Generate a random chess board by playing random plies.
+
+    If ``plies`` is provided, exactly that many plies are played. Otherwise a
+    random number of plies between 1 and ``max_plies`` (inclusive) is used.
+
+    Args:
+        plies: Exact number of plies to play, or ``None`` to choose randomly.
+        max_plies: Upper bound for random plies when ``plies`` is ``None``.
+        seed: Optional RNG seed for determinism.
+
+    Returns:
+        A :class:`chess.Board` after the random plies have been played.
+    """
+
+    rng = np.random.default_rng(seed)
+    b = chess.Board()
+    n = plies if plies is not None else int(rng.integers(1, max_plies + 1))
+    for _ in range(n):
+        if b.is_game_over():
+            break
+        moves = list(b.legal_moves)
+        if not moves:
+            break
+        mv = moves[int(rng.integers(0, len(moves)))]
+        b.push(mv)
+    return b

--- a/azchess/validate_moves.py
+++ b/azchess/validate_moves.py
@@ -4,23 +4,9 @@ import argparse
 from typing import List, Tuple
 
 import chess
-import numpy as np
 
 from .encoding import move_to_index, MoveEncoder
-
-
-def random_board(plies: int = 30, seed: int = 42) -> chess.Board:
-    rng = np.random.default_rng(seed)
-    b = chess.Board()
-    for _ in range(plies):
-        if b.is_game_over():
-            break
-        moves = list(b.legal_moves)
-        if not moves:
-            break
-        mv = moves[int(rng.integers(0, len(moves)))]
-        b.push(mv)
-    return b
+from .utils.board import random_board
 
 
 def validate_board(b: chess.Board) -> Tuple[int, int, List[str]]:

--- a/tests/test_encoding_random.py
+++ b/tests/test_encoding_random.py
@@ -1,22 +1,12 @@
 import chess
 import numpy as np
 
-from azchess.encoding import move_to_index, POLICY_SHAPE, build_horizontal_flip_permutation
-
-
-def random_board(plies: int = 20) -> chess.Board:
-    """Generate a random chess board by playing a number of random plies."""
-    rng = np.random.default_rng()
-    b = chess.Board()
-    for _ in range(plies):
-        if b.is_game_over():
-            break
-        moves = list(b.legal_moves)
-        if not moves:
-            break
-        mv = moves[int(rng.integers(0, len(moves)))]
-        b.push(mv)
-    return b
+from azchess.encoding import (
+    move_to_index,
+    POLICY_SHAPE,
+    build_horizontal_flip_permutation,
+)
+from azchess.utils.board import random_board
 
 
 def test_random_move_indices_unique():


### PR DESCRIPTION
## Summary
- add `random_board` utility for generating random chess positions
- replace duplicate helper functions with shared import in tests and scripts

## Testing
- `pytest tests/test_encoding_random.py`
- `python -m py_compile azchess/validate_moves.py azchess/tools/bench_mcts.py`
- `python -m py_compile azchess/utils/board.py`


------
https://chatgpt.com/codex/tasks/task_e_68a91293082c8323b9bc22fc459fd40f