### PR TITLE
Raise ValueError for illegal moves

### DIFF
--- a/azchess/encoding.py
+++ b/azchess/encoding.py
@@ -109,6 +109,8 @@ def move_to_index(board: chess.Board, move: chess.Move) -> int:
     Map a python-chess Move to [0, 4671] using fixed 64×73 layout.
     Queen promotions are encoded via ray moves; underpromotions occupy the last 9 slots.
     """
+    if not board.is_legal(move):
+        raise ValueError(f"Illegal move: {move}")
     from_sq = move.from_square
     to_sq = move.to_square
     fr, ff = chess.square_rank(from_sq), chess.square_file(from_sq)
@@ -135,11 +137,8 @@ def move_to_index(board: chess.Board, move: chess.Move) -> int:
         if ro is not None:
             return from_sq * 73 + ro
 
-    # Fallback: best-effort map to first legal move from the square
-    for m in board.legal_moves:
-        if m.from_square == from_sq:
-            return move_to_index(board, m)
-    return 0
+    # No valid mapping found: illegal move
+    raise ValueError(f"Illegal move: {move}")
 
 
 @dataclass

--- a/azchess/tools/process_lichess.py
+++ b/azchess/tools/process_lichess.py
@@ -90,12 +90,16 @@ def process_game(game: chess.pgn.Game, min_elo: int):
     for move in game.mainline_moves():
         s = encode_board(board)
         pi = np.zeros(4672, dtype=np.float32)
-        pi[move_to_index(board, move)] = 1.0
-        
+        try:
+            idx = move_to_index(board, move)
+        except ValueError as e:
+            raise ValueError(f"Illegal move {move} in game {headers.get('Event', '')}") from e
+        pi[idx] = 1.0
+
         # Value is from the perspective of the current player
         value = z if board.turn == chess.WHITE else -z
         samples.append({"s": s, "pi": pi, "z": np.float32(value)})
-        
+
         board.push(move)
         
     return samples

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -115,5 +115,17 @@ class TestMoveEncoding(unittest.TestCase):
         self.assertTrue(np.all(encoded[15] == 1.0)) # Black kingside
         self.assertTrue(np.all(encoded[16] == 1.0)) # Black queenside
 
+    def test_illegal_move_to_index_raises(self):
+        """Ensure move_to_index raises on illegal moves."""
+        illegal = chess.Move.from_uci("a1a8")
+        with self.assertRaises(ValueError):
+            move_to_index(self.board, illegal)
+
+    def test_encode_move_illegal_raises(self):
+        """Ensure MoveEncoder.encode_move raises on illegal moves."""
+        illegal = chess.Move.from_uci("a1a8")
+        with self.assertRaises(ValueError):
+            self.encoder.encode_move(self.board, illegal)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- raise `ValueError` in `move_to_index` for non-legal moves instead of silently mapping
- make data conversion tools surface illegal moves
- add regression tests for illegal move encoding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a93ce9a8b48323a8912ae4e687ba87