### PR TITLE
Validate FEN input in new game endpoint

### DIFF
--- a/tests/test_webui_server.py
+++ b/tests/test_webui_server.py
@@ -1,0 +1,26 @@
+import chess
+import pytest
+
+from webui import server
+from webui.server import NewGameRequest, HTTPException
+
+
+@pytest.fixture(autouse=True)
+def stub_dependencies(monkeypatch):
+    monkeypatch.setattr(server, "_load_matrix0", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_jsonl_write", lambda *args, **kwargs: None)
+    server.GAMES.clear()
+
+
+def test_new_game_valid_fen():
+    req = NewGameRequest(fen=chess.STARTING_FEN)
+    resp = server.new_game(req)
+    assert resp["fen"] == chess.STARTING_FEN
+
+
+def test_new_game_invalid_fen():
+    req = NewGameRequest(fen="not a fen")
+    with pytest.raises(HTTPException) as exc:
+        server.new_game(req)
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "invalid FEN"

--- a/webui/server.py
+++ b/webui/server.py
@@ -166,7 +166,10 @@ def _cleanup() -> None:
 def new_game(req: NewGameRequest):
     _load_matrix0()
     game_id = f"g_{int(_now_ts()*1000)}"
-    board = chess.Board(req.fen) if req.fen else chess.Board()
+    try:
+        board = chess.Board(req.fen) if req.fen else chess.Board()
+    except ValueError:
+        raise HTTPException(status_code=400, detail="invalid FEN")
     gs = GameState(
         game_id=game_id,
         created_ts=_now_ts(),


### PR DESCRIPTION
## Summary
- handle invalid FEN strings when creating new games
- add tests covering valid and invalid FEN submissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a93d5d6a8c8323819290512e17ac6e