### PR TITLE
Handle missing uciok during engine init

### DIFF
--- a/benchmarks/uci_bridge.py
+++ b/benchmarks/uci_bridge.py
@@ -60,6 +60,7 @@ class UCIEngine:
             # Initialize UCI protocol
             if not self._initialize_uci():
                 logger.error(f"Failed to initialize UCI protocol for {self.name}")
+                self.stop()
                 return False
 
             # Set options
@@ -143,6 +144,7 @@ class UCIEngine:
         self._send_command("uci")
 
         lines = self._read_response(timeout=2.0)
+        uciok = False
 
         for line in lines:
             if line.startswith("id name"):
@@ -150,9 +152,12 @@ class UCIEngine:
             elif line.startswith("id author"):
                 self.engine_info["author"] = line[9:].strip()
             elif line.startswith("uciok"):
-                return True
+                uciok = True
 
-        # If we didn't get uciok, try anyway
+        if not uciok:
+            logger.error(f"No 'uciok' received from {self.name}")
+            return False
+
         return True
 
     def _set_options(self):


### PR DESCRIPTION
## Summary
- abort startup if UCI initialization doesn't receive `uciok`
- log an error and stop the engine process when `uciok` is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a93d64a3a083238d845baf3618b364