### PR TITLE
chore: remove unused subprocess import

### DIFF
--- a/azchess/engines/uci_bridge.py
+++ b/azchess/engines/uci_bridge.py
@@ -1,7 +1,6 @@
 """UCI protocol bridge for external chess engines."""
 
 import asyncio
-import subprocess
 import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any


### PR DESCRIPTION
## Summary
- remove unnecessary `subprocess` import from UCI bridge

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a941c851b88323af14c206c7ea8c36