### PR TITLE
Forward strict parameter in ResNet load_state_dict

### DIFF
--- a/azchess/model/resnet.py
+++ b/azchess/model/resnet.py
@@ -931,4 +931,4 @@ class PolicyValueNet(nn.Module):
                     elif param_name == 'bias':
                         torch.nn.init.zeros_(param_tensor)
 
-        return super().load_state_dict(new_state_dict, strict=False)
+        return super().load_state_dict(new_state_dict, strict=strict)


### PR DESCRIPTION
## Summary
- ensure PolicyValueNet.load_state_dict forwards the `strict` flag to `nn.Module`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a941bef1008323995efdb1ed239245