### PR TITLE
docs: update roadmap training metrics

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@
 
 **Current Version**: v2.0
 **Last Updated**: August 2025
-**Status**: Production training pipeline active, step 1000+ completed, 53M model stable
+**Status**: Production training pipeline active, step 5000+ completed, 53M model stable
 
 ## Current Achievement Summary
 
@@ -49,7 +49,7 @@ Matrix0 has achieved **production training capability** with a sophisticated 53M
 - [x] **Web interface** for evaluation and analysis
 
 ### 🎯 Training Achievements (August 2025)
-- [x] **Step 1000+ completed** with stable 2.0s/step performance
+- [x] **Step 5000+ completed** with stable ~3-4s/step performance
 - [x] **No NaN/Inf crashes** after branch normalization fixes
 - [x] **Memory optimization** to 14GB MPS limit
 - [x] **SSL curriculum active** with progressive difficulty
@@ -79,8 +79,8 @@ Matrix0 has achieved **production training capability** with a sophisticated 53M
 ## Success Metrics & Timeline
 
 ### Current Performance Metrics
-- **Training Progress**: Step 1000+ completed with stable performance
-- **Training Speed**: ~2.0s per step with 53M parameter model
+- **Training Progress**: Step 5000+ completed with stable performance
+- **Training Speed**: ~3-4s per step with 53M parameter model
 - **Memory Usage**: 14GB MPS limit with automatic management
 - **Stability**: No NaN/Inf crashes with current safeguards
 - **SSL Status**: Multi-task learning with curriculum progression


### PR DESCRIPTION
## Summary
- update roadmap to note training progress at step 5000+
- revise training speed metrics to ~3-4s/step

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a94233690c832391bb1ea1b91d7a16