### PR TITLE
chore: remove unused monitor import

### DIFF
--- a/azchess/orchestrator.py
+++ b/azchess/orchestrator.py
@@ -22,7 +22,6 @@ from .elo import EloBook, update_elo
 import gc
 import torch
 from .data_manager import DataManager
-from .monitor import dir_stats, disk_free, memory_usage_bytes
 import numpy as np
 import time
 import warnings


### PR DESCRIPTION
## Summary
- remove unused monitor import from orchestrator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a94213c49c8323a979b0e3659206a3