### PR TITLE
docs: harmonize training speed references

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -114,7 +114,7 @@
 ### ✅ Core System Achievements
 - **Training Pipeline**: Complete self-play → training → evaluation → promotion cycle ✅ OPERATIONAL
 - **Model Architecture**: 53M parameter ResNet-24 with attention and SSL ✅ PRODUCTION READY
-- **Training Stability**: No NaN/Inf crashes, stable 2.0s/step performance ✅ ACHIEVED
+- **Training Stability**: No NaN/Inf crashes, stable ~3-4 seconds per step ✅ ACHIEVED
 - **Memory Management**: Optimized MPS usage (~10.7-11.0GB) with automatic cleanup ✅ OPTIMIZED
 - **Data Integrity**: SQLite metadata, backup system, corruption detection ✅ ROBUST
 - **Model Evaluation**: Step 3000 evaluation shows +37 ELO improvement ✅ VALIDATED


### PR DESCRIPTION
## Summary
- update status report training speed reference to reflect ~3-4s/step baseline

## Testing
- `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` *(fails: F821 undefined name 'config'; F824 unused globals)*
- `black --check --diff .` *(fails: 55 files would be reformatted)*
- `mypy azchess/ --ignore-missing-imports` *(fails: 171 errors in 21 files)*
- `python -m azchess.model.test_encoding` *(fails: No module named azchess.model.test_encoding)*
- `python -m azchess.model.test_attention` *(fails: No module named azchess.model.test_attention)*

------
https://chatgpt.com/codex/tasks/task_e_68a9422dc8b48323b8dc75f2294ef026