### PR TITLE
gate PERF logs behind debug level

### DIFF
--- a/azchess/training/train.py
+++ b/azchess/training/train.py
@@ -102,7 +102,7 @@ def train_step(model, optimizer, scaler, batch, device: str, accum_steps: int = 
 
     # PERFORMANCE PROFILING: Data prep complete
     data_prep_time = time.time() - data_prep_start
-    if current_step % 10 == 0:  # Log every 10 steps
+    if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):  # Log every 10 steps
         logger.info(f"PERF: Data preparation: {data_prep_time:.3f}s")
 
     # Setup precision and device type BEFORE moving tensors
@@ -182,7 +182,8 @@ def train_step(model, optimizer, scaler, batch, device: str, accum_steps: int = 
     # PERFORMANCE PROFILING: SSL target creation complete
     ssl_target_time = time.time() - ssl_target_start
     if current_step % 10 == 0:
-        logger.info(f"PERF: SSL target creation: {ssl_target_time:.3f}s")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.info(f"PERF: SSL target creation: {ssl_target_time:.3f}s")
         if ssl_target_time > 5.0:  # Log if it's taking too long
             logger.warning(f"SSL target creation is very slow: {ssl_target_time:.3f}s - this indicates a performance issue")
 
@@ -221,7 +222,8 @@ def train_step(model, optimizer, scaler, batch, device: str, accum_steps: int = 
     # PERFORMANCE PROFILING: Forward pass complete
     forward_time = time.time() - forward_start
     if current_step % 10 == 0:
-        logger.info(f"PERF: Forward pass: {forward_time:.3f}s")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.info(f"PERF: Forward pass: {forward_time:.3f}s")
         logger.info(f"DEBUG: Output dtypes - p: {p.dtype}, v: {v.dtype}, ssl_out: {ssl_out.dtype if ssl_out is not None else 'None'}")
 
         # CRITICAL: Validate policy outputs before computing loss
@@ -333,7 +335,7 @@ def train_step(model, optimizer, scaler, batch, device: str, accum_steps: int = 
 
         # PERFORMANCE PROFILING: Loss computation complete
         loss_comp_time = time.time() - loss_comp_start
-        if current_step % 10 == 0:
+        if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
             logger.info(f"PERF: Loss computation: {loss_comp_time:.3f}s")
 
         # CRITICAL FIX: Ensure all loss components have consistent dtypes BEFORE arithmetic
@@ -389,12 +391,12 @@ def train_step(model, optimizer, scaler, batch, device: str, accum_steps: int = 
 
             # PERFORMANCE PROFILING: Backward pass complete
             backward_time = time.time() - backward_start
-            if current_step % 10 == 0:
+            if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
                 logger.info(f"PERF: Backward pass: {backward_time:.3f}s")
 
             # PERFORMANCE PROFILING: Total step time
             total_step_time = time.time() - start_time
-            if current_step % 10 == 0:
+            if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
                 logger.info(f"PERF: Total step time: {total_step_time:.3f}s")
                 logger.info(f"PERF: Breakdown - Data: {data_prep_time:.3f}s, SSL: {ssl_target_time:.3f}s, Forward: {forward_time:.3f}s, Loss: {loss_comp_time:.3f}s, Backward: {backward_time:.3f}s")
         except RuntimeError as e:
@@ -798,7 +800,7 @@ def train_comprehensive(
             try:
                 # PERFORMANCE PROFILING: Batch preparation complete
                 batch_prep_time = time.time() - batch_prep_start
-                if current_step % 10 == 0:
+                if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
                     logger.info(f"PERF: Batch preparation: {batch_prep_time:.3f}s")
 
                 # PERFORMANCE PROFILING: Start train_step
@@ -829,7 +831,7 @@ def train_comprehensive(
                 
                 # PERFORMANCE PROFILING: train_step complete
                 train_step_time = time.time() - train_step_start
-                if current_step % 10 == 0:
+                if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
                     logger.info(f"PERF: train_step call: {train_step_time:.3f}s")
 
                 loss, policy_loss, value_loss, ssl_loss, wdl_loss = loss_values
@@ -942,7 +944,7 @@ def train_comprehensive(
 
                     # PERFORMANCE PROFILING: Optimizer step complete
                     optimizer_time = time.time() - optimizer_start
-                    if current_step % 10 == 0:
+                    if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
                         logger.info(f"PERF: Optimizer step: {optimizer_time:.3f}s")
 
                     # Update watchdog timer
@@ -950,12 +952,12 @@ def train_comprehensive(
 
                     # PERFORMANCE PROFILING: Post-processing complete
                     post_proc_time = time.time() - post_proc_start
-                    if current_step % 10 == 0:
+                    if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
                         logger.info(f"PERF: Post-processing: {post_proc_time:.3f}s")
 
                     # PERFORMANCE PROFILING: Total iteration time
                     total_iter_time = time.time() - batch_prep_start
-                    if current_step % 10 == 0:
+                    if current_step % 10 == 0 and logger.isEnabledFor(logging.DEBUG):
                         logger.info(f"PERF: Total iteration: {total_iter_time:.3f}s")
                         logger.info(f"PERF: Full breakdown - Batch: {batch_prep_time:.3f}s, TrainStep: {train_step_time:.3f}s, Post: {post_proc_time:.3f}s, Optimizer: {optimizer_time:.3f}s")
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,3 +193,19 @@ training:
   batch_size: 192                  # MPS-optimized batch size
   precision: "fp16"                # Mixed precision training
 ```
+
+### Performance Logging
+Matrix0 includes optional performance diagnostics that log timing information for
+training steps. These messages are prefixed with `PERF:` and are disabled by
+default. To enable them, configure logging at the `DEBUG` level:
+
+```python
+import logging
+from azchess.logging_utils import setup_logging
+
+# Enable performance diagnostics
+logger = setup_logging(level=logging.DEBUG)
+```
+
+With this configuration, the training scripts will emit detailed performance
+metrics. Running at the default `INFO` level suppresses these messages.


### PR DESCRIPTION
## Summary
- wrap all PERF logs with debug level checks
- document how to enable performance diagnostics via logging

## Testing
- `pytest`
- `python - <<'PY'
import logging
import numpy as np
import torch
from torch import nn
from azchess.training.train import train_step, POLICY_SHAPE
from azchess.logging_utils import setup_logging

logger = setup_logging(level=logging.INFO)

class DummyModel(nn.Module):
    def __init__(self):
        super().__init__()
        self.fc_policy = nn.Linear(19*8*8, np.prod(POLICY_SHAPE))
        self.fc_value = nn.Linear(19*8*8, 1)
    def forward(self, x, return_ssl=True):
        x = x.view(x.size(0), -1)
        p = self.fc_policy(x)
        v = self.fc_value(x).squeeze(-1)
        ssl = torch.zeros((x.size(0), 1), device=x.device)
        return p, v, ssl
    def create_ssl_targets(self, s):
        return torch.zeros(s.size(0), dtype=torch.long)
    def get_ssl_loss(self, s, ssl_targets):
        return torch.tensor(0.0, device=s.device, requires_grad=False)

model = DummyModel()
optimizer = torch.optim.SGD(model.parameters(), lr=0.01)

batch_size = 1
s = np.random.randn(batch_size, 19, 8, 8).astype(np.float32)
pi = np.random.randn(batch_size, np.prod(POLICY_SHAPE)).astype(np.float32)
z = np.random.randn(batch_size).astype(np.float32)

train_step(model, optimizer, None, (s, pi, z), device='cpu', accum_steps=1,
           augment=False, enable_ssl=True, policy_masking=False, precision='fp32', current_step=0)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a9450335c48323b529a1a7a22d5a82