### PR TITLE
refactor: drop path hack and document training module usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ source .venv/bin/activate
 python -m azchess.orchestrator --workers 2 --sims 300 --lr 0.001 --batch-size 192 --epochs 10 --eval-games 50 --device mps
 ```
 
+Run the training loop directly without the orchestrator:
+
+```bash
+python -m azchess.training.train --config config.yaml
+```
+
 ### 4. Monitor & Interact
 ```bash
 # Interactive play against current model

--- a/azchess/training/train.py
+++ b/azchess/training/train.py
@@ -15,9 +15,6 @@ from pathlib import Path
 from datetime import datetime, timedelta
 import argparse
 
-# Add project root to path
-sys.path.append(str(Path(__file__).parent))
-
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -1257,4 +1254,5 @@ def train_from_config(config_path: str = "config.yaml"):
     )
 
 if __name__ == "__main__":
+    # Allows running with: python -m azchess.training.train
     main()


### PR DESCRIPTION
## Summary
- remove `sys.path` modification from `train.py`
- clarify `python -m azchess.training.train` entry point and usage
- document direct training invocation in README

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a94519b6288323a08bcc2365fd7fa2