### PR TITLE
Refactor SelfPlayManager for thread-safe MCTS and add concurrency test

### DIFF
--- a/tests/test_selfplay_manager.py
+++ b/tests/test_selfplay_manager.py
@@ -1,0 +1,44 @@
+import random
+import numpy as np
+import torch
+import chess
+
+from experiments.grpo.mcts.mcts_integration import MCTS, MCTSConfig, SelfPlayManager
+
+
+class DummyModel(torch.nn.Module):
+    def forward(self, x):
+        batch = x.shape[0]
+        policy = torch.zeros((batch, 4672), dtype=torch.float32)
+        value = torch.zeros((batch, 1), dtype=torch.float32)
+        return policy, value
+
+
+class DeterministicMCTS(MCTS):
+    def _sample_move_from_policy(self, policy, legal_moves):
+        return legal_moves[0], 0.0
+
+
+def mcts_factory():
+    model = DummyModel()
+    cfg = MCTSConfig(num_simulations=1, dirichlet_frac=0.0)
+    return DeterministicMCTS(model, cfg)
+
+
+def _set_seeds():
+    random.seed(0)
+    np.random.seed(0)
+    torch.manual_seed(0)
+
+
+def _generate_games():
+    spm = SelfPlayManager(mcts_factory, num_workers=4)
+    return spm.generate_games(num_games=8, max_moves=2)
+
+
+def test_selfplay_manager_deterministic_concurrent():
+    _set_seeds()
+    games1 = _generate_games()
+    _set_seeds()
+    games2 = _generate_games()
+    assert games1 == games2


### PR DESCRIPTION
## Summary
- Instantiate a dedicated MCTS instance for each self-play worker to avoid shared state contention.
- Document concurrent game generation in SelfPlayManager.
- Add a stress test that generates games concurrently and asserts deterministic results.

## Testing
- `pytest tests/test_selfplay_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a01cc9ac8323b4dd6b3febf849dc