### PR TITLE
feat(grpo): add meta-learning parameter tuning and reward shaping

### DIFF
--- a/experiments/grpo/README.md
+++ b/experiments/grpo/README.md
@@ -51,7 +51,20 @@ magnus_transformer_grpo:
   training:
     num_games_per_epoch: 50  # Games per training epoch
     max_epochs: 25          # Total training epochs
+
+  meta_learning:
+    enabled: true           # Adjust GRPO params based on win rate
+    adaptation_freq: 5      # Epochs between parameter updates
+
+  reward_shaping:
+    enabled: true           # Inject heuristic rewards during self-play
 ```
+
+When `meta_learning.enabled` is true the orchestrator uses a lightweight
+meta-learner to nudge learning rate and clipping parameters based on the
+current evaluation win rate.  Enabling `reward_shaping` applies the
+`ChessRewardShaper` during trajectory conversion so that additional
+heuristic rewards are added to each step.
 
 ## Future Research Directions
 

--- a/experiments/grpo/training/reward_shaping.py
+++ b/experiments/grpo/training/reward_shaping.py
@@ -387,6 +387,19 @@ def create_adaptive_reward_shaper(d_model: int = 512) -> AdaptiveRewardShaper:
     return AdaptiveRewardShaper(d_model)
 
 
+class RewardShapingCallback:
+    """Simple callable used by the orchestrator to inject shaped rewards."""
+
+    def __init__(self, weights: Optional[Dict[str, float]] = None):
+        self.shaper = ChessRewardShaper()
+        self.weights = weights or {}
+
+    def __call__(self, board: chess.Board, move: Optional[chess.Move] = None,
+                 game_result: float = 0.0) -> float:
+        components = self.shaper.shape_reward(board, move, game_result)
+        return components.total_reward(self.weights)
+
+
 if __name__ == "__main__":
     # Test the reward shaper
     print("Testing Chess Reward Shaper...")


### PR DESCRIPTION
## Summary
- add lightweight meta-learner that adjusts GRPO parameters based on evaluation win rate
- provide reward shaping callback to inject chess-specific heuristic rewards
- wire meta-learning and reward shaping options into GRPO orchestrator with documented config usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a017342c832388365d61d3d4577e