### PR TITLE
refactor: centralize board encoding

### DIFF
--- a/experiments/grpo/mcts/mcts_integration.py
+++ b/experiments/grpo/mcts/mcts_integration.py
@@ -16,6 +16,7 @@ import math
 from typing import List, Dict, Tuple, Optional, Any
 from dataclasses import dataclass
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from utils.board_encoding import board_to_tensor
 
 logger = logging.getLogger(__name__)
 
@@ -264,7 +265,7 @@ class MCTS:
         roots = [MCTSNode(board=b.copy()) for b in boards]
         
         # First, evaluate all root positions in a batch
-        board_tensors = torch.cat([self._board_to_tensor(b) for b in boards])
+        board_tensors = torch.cat([board_to_tensor(b) for b in boards])
         policy_logits_batch, value_batch = self.model(board_tensors.to(self.device))
 
         for i, root in enumerate(roots):
@@ -328,7 +329,7 @@ class MCTS:
     def _evaluate_position(self, board: chess.Board) -> Tuple[torch.Tensor, float]:
         """Evaluate position using neural network"""
         try:
-            board_tensor = self._board_to_tensor(board)
+            board_tensor = board_to_tensor(board)
             
             if board_tensor is None or board_tensor.numel() == 0:
                 logger.error("Invalid board tensor generated")
@@ -352,58 +353,6 @@ class MCTS:
             logger.error(f"Position evaluation failed: {e}")
             return torch.zeros(4672), 0.0
 
-    def _board_to_tensor(self, board: chess.Board) -> torch.Tensor:
-        """Convert chess board to tensor format compatible with transformer"""
-        # Create 19-channel board representation
-        channels = []
-
-        # Piece channels (12 channels: 6 piece types x 2 colors)
-        for piece_type in range(1, 7):  # 1-6: pawn, knight, bishop, rook, queen, king
-            white_channel = torch.zeros(8, 8)
-            black_channel = torch.zeros(8, 8)
-
-            for square in chess.SQUARES:
-                piece = board.piece_at(square)
-                if piece and piece.piece_type == piece_type:
-                    row, col = divmod(square, 8)
-                    if piece.color == chess.WHITE:
-                        white_channel[row, col] = 1.0
-                    else:
-                        black_channel[row, col] = 1.0
-
-            channels.extend([white_channel, black_channel])
-
-        # Additional channels for game state (7 more to make 19 total)
-        # Side to move
-        side_to_move = torch.ones(8, 8) if board.turn == chess.WHITE else torch.zeros(8, 8)
-        channels.append(side_to_move)
-
-        # Castling rights (4 channels)
-        castling_channels = []
-        for i in range(4):
-            castling_channels.append(torch.zeros(8, 8))
-        if board.has_kingside_castling_rights(chess.WHITE):
-            castling_channels[0].fill_(1.0)
-        if board.has_queenside_castling_rights(chess.WHITE):
-            castling_channels[1].fill_(1.0)
-        if board.has_kingside_castling_rights(chess.BLACK):
-            castling_channels[2].fill_(1.0)
-        if board.has_queenside_castling_rights(chess.BLACK):
-            castling_channels[3].fill_(1.0)
-        channels.extend(castling_channels)
-
-        # En passant (1 channel)
-        en_passant = torch.zeros(8, 8)
-        if board.ep_square:
-            row, col = divmod(board.ep_square, 8)
-            en_passant[row, col] = 1.0
-        channels.append(en_passant)
-
-        # Halfmove clock (1 channel)
-        halfmove = torch.full((8, 8), min(board.halfmove_clock / 100.0, 1.0))
-        channels.append(halfmove)
-
-        return torch.stack(channels, dim=0).unsqueeze(0)  # Add batch dimension
 
     def _get_policy_from_visits(self, root: MCTSNode, legal_moves: List[chess.Move]) -> torch.Tensor:
         """Extract policy from visit counts"""
@@ -484,7 +433,7 @@ class MCTS:
             for i, step in enumerate(trajectory):
                 step['reward'] = result if i == len(trajectory) - 1 else 0.0
                 step['done'] = i == len(trajectory) - 1
-                step['state'] = self._board_to_tensor(step['board'])
+                step['state'] = board_to_tensor(step['board'])
                 step['action'] = self._move_to_index(step['move'])
 
         logger.info(f"Trajectory generation complete: {len(trajectory)} steps, final result: {result}")

--- a/experiments/grpo/utils/board_encoding.py
+++ b/experiments/grpo/utils/board_encoding.py
@@ -1,0 +1,57 @@
+import torch
+import chess
+
+def board_to_tensor(board: chess.Board) -> torch.Tensor:
+    """Convert a chess.Board to a (1, 19, 8, 8) tensor.
+
+    Channels are ordered as:
+        0-11: piece planes (white then black for P,N,B,R,Q,K)
+        12: side to move (1 if white, 0 if black)
+        13-16: castling rights (W-K, W-Q, B-K, B-Q)
+        17: en passant target square
+        18: halfmove clock normalized to [0,1] with cap at 100
+    """
+    channels = []
+
+    # Piece channels
+    for piece_type in range(1, 7):  # 1-6: pawn, knight, bishop, rook, queen, king
+        white_channel = torch.zeros(8, 8)
+        black_channel = torch.zeros(8, 8)
+        for square in chess.SQUARES:
+            piece = board.piece_at(square)
+            if piece and piece.piece_type == piece_type:
+                row, col = divmod(square, 8)
+                if piece.color == chess.WHITE:
+                    white_channel[row, col] = 1.0
+                else:
+                    black_channel[row, col] = 1.0
+        channels.extend([white_channel, black_channel])
+
+    # Side to move
+    side_to_move = torch.ones(8, 8) if board.turn == chess.WHITE else torch.zeros(8, 8)
+    channels.append(side_to_move)
+
+    # Castling rights
+    castling_channels = [torch.zeros(8, 8) for _ in range(4)]
+    if board.has_kingside_castling_rights(chess.WHITE):
+        castling_channels[0].fill_(1.0)
+    if board.has_queenside_castling_rights(chess.WHITE):
+        castling_channels[1].fill_(1.0)
+    if board.has_kingside_castling_rights(chess.BLACK):
+        castling_channels[2].fill_(1.0)
+    if board.has_queenside_castling_rights(chess.BLACK):
+        castling_channels[3].fill_(1.0)
+    channels.extend(castling_channels)
+
+    # En passant square
+    en_passant = torch.zeros(8, 8)
+    if board.ep_square is not None:
+        row, col = divmod(board.ep_square, 8)
+        en_passant[row, col] = 1.0
+    channels.append(en_passant)
+
+    # Halfmove clock (normalized)
+    halfmove = torch.full((8, 8), min(board.halfmove_clock / 100.0, 1.0))
+    channels.append(halfmove)
+
+    return torch.stack(channels, dim=0).unsqueeze(0)

--- a/tests/test_board_tensor.py
+++ b/tests/test_board_tensor.py
@@ -1,0 +1,31 @@
+import chess
+import torch
+
+from experiments.grpo.utils.board_encoding import board_to_tensor
+
+
+def test_board_to_tensor_consistency():
+    """Board encoding should match expected channel semantics."""
+    board = chess.Board("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")
+    tensor = board_to_tensor(board)
+
+    assert tensor.shape == (1, 19, 8, 8)
+
+    # White pawn on e4
+    assert tensor[0, 0, 3, 4] == 1.0
+    # Black pawn on a7
+    assert tensor[0, 1, 6, 0] == 1.0
+
+    # Side to move: black
+    assert torch.equal(tensor[0, 12], torch.zeros(8, 8))
+
+    # All castling rights available
+    for idx in range(13, 17):
+        assert torch.equal(tensor[0, idx], torch.ones(8, 8))
+
+    # En passant square at e3
+    assert tensor[0, 17, 2, 4] == 1.0
+
+    # Halfmove clock zero
+    assert torch.equal(tensor[0, 18], torch.zeros(8, 8))
+


### PR DESCRIPTION
## Summary
- add shared `board_to_tensor` utility for GRPO experiments
- reuse encoding in GRPO orchestrator and MCTS integration
- add regression test for board encoding semantics

## Testing
- `pytest tests/test_board_tensor.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a0168abc8323aab0ceb010af4d8f