### PR TITLE
Preserve batch order in MCTS search results

### DIFF
--- a/experiments/grpo/mcts/mcts_integration.py
+++ b/experiments/grpo/mcts/mcts_integration.py
@@ -271,10 +271,17 @@ class MCTS:
             legal_moves = list(root.board.legal_moves)
             root.expand(legal_moves, policy_logits_batch[i], self.config)
 
-        # Then, run simulations for each root
+        # Then, run simulations for each root while preserving input order
         with ThreadPoolExecutor(max_workers=self.config.batch_size) as executor:
-            futures = [executor.submit(self._run_simulations_for_root, root) for root in roots]
-            results = [future.result() for future in as_completed(futures)]
+            future_to_index = {
+                executor.submit(self._run_simulations_for_root, root): idx
+                for idx, root in enumerate(roots)
+            }
+
+            results = [None] * len(roots)
+            for future in as_completed(future_to_index):
+                idx = future_to_index[future]
+                results[idx] = future.result()
 
         logger.debug(f"Batch search completed for {len(boards)} positions")
         return results

--- a/tests/test_mcts_batch_order.py
+++ b/tests/test_mcts_batch_order.py
@@ -1,0 +1,45 @@
+import hashlib
+from unittest.mock import patch
+
+import chess
+import torch
+
+from experiments.grpo.mcts.mcts_integration import MCTS, MCTSConfig
+
+
+class DummyModel(torch.nn.Module):
+    def forward(self, x):
+        batch = x.shape[0]
+        policy = torch.zeros((batch, 4672), dtype=torch.float32)
+        value = torch.zeros((batch, 1), dtype=torch.float32)
+        return policy, value
+
+
+def _uid(board: chess.Board) -> int:
+    return int(hashlib.md5(board.fen().encode()).hexdigest(), 16) % 1000
+
+
+def test_search_batch_preserves_input_order():
+    model = DummyModel()
+    cfg = MCTSConfig(num_simulations=0, batch_size=2)
+    mcts = MCTS(model, cfg)
+
+    board1 = chess.Board()
+    board2 = chess.Board()
+    board2.push_san("e4")
+    boards = [board1, board2]
+
+    def fake_run(self, root):
+        uid = _uid(root.board)
+        policy = torch.full((4672,), float(uid))
+        value = float(uid)
+        return policy, value
+
+    with patch.object(MCTS, "_run_simulations_for_root", fake_run):
+        results = mcts.search_batch(boards)
+
+    assert len(results) == len(boards)
+    for (policy, value), board in zip(results, boards):
+        uid = _uid(board)
+        assert policy[0].item() == float(uid)
+        assert value == float(uid)


### PR DESCRIPTION
## Summary
- Ensure `search_batch` returns results in the same order as input boards by tracking future indices
- Add unit test verifying batch order preservation in `search_batch`

## Testing
- `pytest tests/test_mcts_batch_order.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a02127988323945d5512fe6ee447