### PR TITLE
Implement cpuct schedule and virtual loss tracking for GRPO MCTS

### DIFF
--- a/tests/test_mcts_no_psutil.py
+++ b/tests/test_mcts_no_psutil.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import chess
 import torch
+import logging
 
 
 def _get_mcts_module_without_psutil():
@@ -29,6 +30,8 @@ def test_mcts_runs_without_psutil():
 
     model = DummyModel()
     cfg = mcts_mod.MCTSConfig(num_simulations=1, batch_size=1)
+    logging.getLogger().handlers = []
+    logging.basicConfig(level=logging.WARNING)
     mcts = mcts_mod.MCTS(cfg, model)
     board = chess.Board()
     moves, policy, value = mcts.run(board, num_simulations=1)

--- a/tests/test_mcts_virtual_loss.py
+++ b/tests/test_mcts_virtual_loss.py
@@ -1,0 +1,42 @@
+import chess
+import torch
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+from experiments.grpo.mcts.mcts_integration import MCTS, MCTSConfig, MCTSNode
+
+logging.raiseExceptions = False
+root_logger = logging.getLogger()
+for handler in list(root_logger.handlers):
+    root_logger.removeHandler(handler)
+logging.basicConfig(level=logging.WARNING)
+
+
+class DummyModel(torch.nn.Module):
+    def forward(self, x):
+        batch = x.shape[0]
+        p = torch.ones((batch, 4672), dtype=torch.float32)
+        v = torch.zeros((batch, 1), dtype=torch.float32)
+        return p, v
+
+
+def test_virtual_loss_reduces_leaf_collisions():
+    model = DummyModel()
+    cfg = MCTSConfig(num_simulations=1, batch_size=1)
+    mcts = MCTS(model, cfg)
+    board = chess.Board()
+
+    # Prepare root with only two children to force contention
+    root = MCTSNode(board=board.copy())
+    policy_logits, _ = mcts._evaluate_position(board)
+    legal_moves = list(board.legal_moves)[:2]
+    root.expand(legal_moves, policy_logits, cfg)
+
+    # Run two simulations in parallel; without virtual loss they would collide
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(mcts._simulate, root) for _ in range(2)]
+        for f in futures:
+            f.result()
+
+    visits = [child.visit_count for child in root.children.values()]
+    assert sorted(visits) == [1, 1], f"Unexpected visit counts: {visits}"


### PR DESCRIPTION
## Summary
- Add per-depth cpuct schedule and virtual loss handling to GRPO MCTS
- Support dynamic cpuct in child selection and virtual loss during simulation
- Add test exercising multi-threaded MCTS to ensure leaf collisions are reduced

## Testing
- `pytest tests/test_mcts_virtual_loss.py tests/test_mcts_no_psutil.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a02523b0832383eb7f7a7cb6fa7d