### PR TITLE
Normalize fallback MCTS probabilities

### DIFF
--- a/experiments/grpo/mcts/mcts_integration.py
+++ b/experiments/grpo/mcts/mcts_integration.py
@@ -541,15 +541,19 @@ class MCTS:
         except Exception as e:
             logger.warning(f"Error in move sampling: {e}, falling back to numpy sampling")
             # Fallback to numpy sampling
-            sampled_idx = np.random.choice(len(legal_indices), p=legal_probs)
+            legal_probs_np = np.array(legal_probs, dtype=np.float64)
+            if legal_probs_np.sum() > 0:
+                legal_probs_np /= legal_probs_np.sum()
+            else:
+                legal_probs_np = np.ones(len(legal_indices), dtype=np.float64) / len(legal_indices)
+
+            sampled_idx = np.random.choice(len(legal_indices), p=legal_probs_np)
             sampled_move_idx = legal_indices[sampled_idx]
 
             # Find corresponding move
             for move in legal_moves:
                 if self._move_to_index(move) == sampled_move_idx:
-                    # Calculate log probability
-                    total_prob = sum(legal_probs)
-                    move_prob = legal_probs[sampled_idx] / total_prob if total_prob > 0 else 1.0 / len(legal_moves)
+                    move_prob = legal_probs_np[sampled_idx]
                     log_prob = math.log(move_prob + 1e-8)
                     return move, log_prob
 

--- a/tests/test_mcts_sampling.py
+++ b/tests/test_mcts_sampling.py
@@ -1,0 +1,34 @@
+import math
+import numpy as np
+import chess
+import torch
+import pytest
+
+from experiments.grpo.mcts.mcts_integration import MCTS, MCTSConfig
+
+def test_fallback_sampling_matches_torch(monkeypatch):
+    mcts = MCTS(model=None, config=MCTSConfig(), device="cpu")
+    board = chess.Board()
+    legal_moves = list(board.legal_moves)[:2]
+
+    policy = torch.zeros(4672)
+    for move in legal_moves:
+        idx = mcts._move_to_index(move)
+        policy[idx] = 1.0
+
+    torch.manual_seed(0)
+    np.random.seed(0)
+    move_torch, log_prob_torch = mcts._sample_move_from_policy(policy, legal_moves)
+
+    def fail_multinomial(*args, **kwargs):
+        raise RuntimeError("forced error")
+
+    monkeypatch.setattr(torch, "multinomial", fail_multinomial)
+
+    torch.manual_seed(0)
+    np.random.seed(0)
+    move_np, log_prob_np = mcts._sample_move_from_policy(policy, legal_moves)
+
+    assert move_np in legal_moves
+    assert math.isclose(log_prob_np, log_prob_torch)
+    assert math.isclose(log_prob_np, math.log(0.5))


### PR DESCRIPTION
## Summary
- Normalize legal move probabilities before numpy-based sampling to keep distributions valid
- Add unit test ensuring numpy fallback sampling aligns with the torch multinomial path

## Testing
- `pytest tests/test_mcts_sampling.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c1a01a23408323a8379b00d082caaf