### PR TITLE
Add system metrics endpoint for dashboard

### DIFF
--- a/azchess/monitor.py
+++ b/azchess/monitor.py
@@ -45,3 +45,18 @@ def memory_usage_bytes() -> Optional[int]:
     except Exception:
         return None
 
+
+def get_memory_usage(device: str = "auto") -> dict:
+    """Proxy to the unified memory usage helper.
+
+    The web UI expects ``azchess.monitor`` to expose a ``get_memory_usage``
+    helper.  Delegate to :func:`azchess.utils.get_memory_usage` lazily to avoid
+    introducing an import cycle.
+    """
+
+    # Import locally to avoid importing azchess.utils at module import time and
+    # to keep this module lightweight.
+    from .utils import get_memory_usage as _get_memory_usage  # type: ignore
+
+    return _get_memory_usage(device)
+

--- a/tests/test_webui_server.py
+++ b/tests/test_webui_server.py
@@ -24,3 +24,35 @@ def test_new_game_invalid_fen():
         server.new_game(req)
     assert exc.value.status_code == 400
     assert exc.value.detail == "invalid FEN"
+
+
+def test_system_metrics_endpoint(monkeypatch):
+    sample_memory = {"device": "cpu", "memory_gb": 12.5, "available": True}
+    monkeypatch.setattr(server.monitor, "get_memory_usage", lambda device='auto': sample_memory)
+    monkeypatch.setattr(server, "training_status", lambda: {"is_training": True, "progress": 47.5})
+    monkeypatch.setattr(server, "ssl_status", lambda: {"enabled": True, "tasks": ["task1", "task2"]})
+    monkeypatch.setattr(server, "list_tournaments", lambda: {"total_active": 3, "total_completed": 1})
+
+    server.GAMES["gid"] = server.GameState(
+        game_id="gid",
+        created_ts=0.0,
+        board=chess.Board(),
+        white="human",
+        black="matrix0",
+        moves=[],
+        engine_tc_ms=100,
+    )
+
+    metrics = server.system_metrics()
+
+    assert metrics["memory"] == sample_memory
+    assert metrics["active_games"] == 1
+    assert metrics["training"]["is_training"] is True
+    assert metrics["training"]["progress"] == 47.5
+    assert metrics["ssl"]["enabled"] is True
+    assert metrics["ssl"]["task_count"] == 2
+    assert metrics["tournaments"]["active"] == 3
+    assert metrics["tournaments"]["completed"] == 1
+    assert isinstance(metrics["timestamp"], float)
+
+    server.GAMES.clear()


### PR DESCRIPTION
## Summary
- expose a `/system/metrics` FastAPI endpoint that aggregates memory usage, active games, training, SSL, and tournament counts for the dashboard
- re-export `get_memory_usage` from `azchess.monitor` so the web UI can query process memory statistics
- update the frontend system metrics widget to consume the new API instead of hardcoded placeholders and expand test coverage for the schema

## Testing
- pytest tests/test_webui_server.py


------
https://chatgpt.com/codex/tasks/task_e_68cdda703040832390949bfd364d12eb