### PR TITLE
Fix inference caching shared-memory aliasing

### DIFF
--- a/azchess/mcts.py
+++ b/azchess/mcts.py
@@ -332,7 +332,7 @@ class MCTS:
                     # Cache miss: recompute value without expanding existing root
                     p_logits, v = self._infer(board)
                     # Ensure recomputed result is stored for future lookups
-                    self.nn_cache.put(key, (p_logits, v))
+                    self.nn_cache.put(key, (np.array(p_logits, copy=True), v))
                 else:
                     # Use cached value when available
                     _, v = cached

--- a/azchess/selfplay/inference.py
+++ b/azchess/selfplay/inference.py
@@ -577,8 +577,16 @@ class InferenceClient:
                 try:
                     if self.res["response_event"].wait(timeout=timeout):
                         # Response received, copy results
-                        policy = self.res["response_policy_tensor"][:batch_size].numpy()
-                        value = self.res["response_value_tensor"][:batch_size].numpy()
+                        policy = (
+                            self.res["response_policy_tensor"][:batch_size]
+                            .numpy()
+                            .copy()
+                        )
+                        value = (
+                            self.res["response_value_tensor"][:batch_size]
+                            .numpy()
+                            .copy()
+                        )
                         
                         # Clear response event for next use
                         self.res["response_event"].clear()

--- a/tests/test_inference_shared.py
+++ b/tests/test_inference_shared.py
@@ -1,0 +1,43 @@
+import numpy as np
+import torch
+
+from azchess.selfplay.inference import InferenceClient, setup_shared_memory_for_worker
+
+
+def test_inference_client_returns_copies_between_calls():
+    planes = 1
+    policy_size = 4
+    max_batch_size = 2
+    resources = setup_shared_memory_for_worker(
+        worker_id=0, planes=planes, policy_size=policy_size, max_batch_size=max_batch_size
+    )
+    client = InferenceClient(resources)
+
+    first_policy = np.array([[0.1, 0.2, 0.3, 0.4]], dtype=np.float32)
+    first_value = np.array([[0.5]], dtype=np.float32)
+
+    resources["response_policy_tensor"][:1] = torch.from_numpy(first_policy)
+    resources["response_value_tensor"][:1] = torch.from_numpy(first_value)
+    resources["response_event"].set()
+
+    request_batch = np.zeros((1, planes, 8, 8), dtype=np.float32)
+    policy_first, value_first = client.infer_np(request_batch)
+
+    np.testing.assert_allclose(policy_first, first_policy)
+    np.testing.assert_allclose(value_first, first_value.flatten())
+
+    second_policy = np.array([[0.9, 0.1, 0.0, 0.0]], dtype=np.float32)
+    second_value = np.array([[-0.25]], dtype=np.float32)
+
+    resources["response_policy_tensor"][:1] = torch.from_numpy(second_policy)
+    resources["response_value_tensor"][:1] = torch.from_numpy(second_value)
+    resources["response_event"].set()
+
+    request_batch_2 = np.ones((1, planes, 8, 8), dtype=np.float32)
+    policy_second, value_second = client.infer_np(request_batch_2)
+
+    np.testing.assert_allclose(policy_second, second_policy)
+    np.testing.assert_allclose(value_second, second_value.flatten())
+
+    np.testing.assert_allclose(policy_first, first_policy)
+    np.testing.assert_allclose(value_first, first_value.flatten())


### PR DESCRIPTION
## Summary
- copy shared inference responses before returning to the client to avoid shared-memory aliasing
- ensure policy logits stored in the nn_cache are copied for stability
- add a regression test covering consecutive shared-inference calls

## Testing
- pytest tests/test_inference_shared.py

------
https://chatgpt.com/codex/tasks/task_e_68d1b3da58a883239ace9ad07468d107