### PR TITLE
Clarify SSL task availability across docs

### DIFF
--- a/docs/CURRENT_STATUS_SUMMARY.md
+++ b/docs/CURRENT_STATUS_SUMMARY.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-Matrix0 has achieved **SSL architecture integration** with a sophisticated 53M parameter model featuring advanced multi-task SSL learning framework. The system includes **5 SSL tasks: piece recognition, threat detection, pin detection, fork detection, and control detection** - all integrated with the training pipeline architecture. **Data pipeline issues have been resolved** including SSL target concatenation, shape mismatches, and value target corrections. **EX0Bench system provides pure external engine battles** for Stockfish vs LC0 performance analysis. **Training stability issues have been resolved** with proper scheduler stepping and gradient management. **Enhanced WebUI provides comprehensive monitoring** of SSL performance, training metrics, and model analysis.
+Matrix0 has achieved **SSL architecture integration** with a sophisticated 53M parameter model featuring advanced multi-task SSL learning framework. The system includes **5 SSL tasks: piece recognition, threat detection, pin detection, fork detection, and control detection** - all integrated with the training pipeline architecture. **Data pipeline issues have been resolved** including SSL target concatenation, shape mismatches, and value target corrections. **EX0Bench system provides pure external engine battles** for Stockfish vs LC0 performance analysis. **Training stability issues have been resolved** with proper scheduler stepping and gradient management. **Enhanced WebUI provides comprehensive monitoring** of SSL performance, training metrics, and model analysis. Two additional SSL heads (**pawn structure** and **king safety**) exist in the codebase but are currently disabled while we gather reliable targets and validation metrics.
 
 ## ✅ What's Actually Working (Current Reality)
 
@@ -30,6 +30,7 @@ Matrix0 has achieved **SSL architecture integration** with a sophisticated 53M p
 - **Fork Detection**: ✅ Identifies forking opportunities and threats
 - **Control Detection**: ✅ Analyzes square control and influence
 - **SSL Loss Integration**: ✅ Weighted SSL loss with policy/value learning
+- **Experimental Heads (Future)**: Pawn structure and king safety detection implemented but disabled pending data validation
 
 ### Apple Silicon Optimization
 - **MPS Memory**: ✅ 14GB limit with automatic management and cache clearing
@@ -133,10 +134,11 @@ Matrix0 has achieved **SSL architecture integration** with a sophisticated 53M p
 ## Current Development Priorities
 
 ### Priority 1: SSL Performance Validation (1-2 weeks)
-1. **SSL Learning Effectiveness**: Measure and validate SSL task learning across all 7 objectives
+1. **SSL Learning Effectiveness**: Measure and validate SSL task learning across all 5 production objectives
 2. **SSL Contribution Analysis**: Quantify SSL impact on policy/value learning
 3. **SSL Task Balancing**: Optimize loss weights for balanced multi-task learning
 4. **SSL Curriculum Tuning**: Fine-tune progressive difficulty parameters
+5. **Experimental Task Planning**: Define data requirements for pawn structure and king safety heads before activation
 
 ### Priority 2: Enhanced Evaluation System (2-3 weeks)
 1. **Multi-Engine Tournaments**: Automated competitive evaluation against Stockfish/LC0
@@ -155,7 +157,7 @@ Matrix0 has achieved **SSL architecture integration** with a sophisticated 53M p
 ### Training Performance
 - **Training Speed**: ~3-4 seconds per step (optimized for SSL integration)
 - **Memory Usage**: ~10.7-11.0GB MPS usage (stable with SSL processing)
-- **SSL Status**: ✅ **ARCHITECTURE INTEGRATED** - All 7 SSL tasks integrated, performance validation in progress
+- **SSL Status**: ✅ **ARCHITECTURE INTEGRATED** - Five production SSL tasks active; pawn structure and king safety heads staged for future validation
 - **Training Stability**: ✅ **100% stable** - No NaN/Inf issues with SSL
 - **Multi-Task Learning**: ✅ Simultaneous policy, value, and SSL optimization
 
@@ -205,7 +207,7 @@ Matrix0 has achieved **SSL architecture integration** with a sophisticated 53M p
 ## Success Metrics & Timeline
 
 ### Immediate (Completed - August 27, 2025)
-- ✅ **SSL Integration**: All 7 SSL algorithms fully integrated with training pipeline
+- ✅ **SSL Integration**: Five production SSL algorithms (piece, threat, pin, fork, control) fully integrated with the training pipeline; experimental pawn structure and king safety heads remain disabled pending validation
 - ✅ **Multi-Task Learning**: Working SSL curriculum with progressive difficulty
 - ✅ **Training Stability**: 100% stable training with full SSL capabilities
 - ✅ **WebUI Enhancement**: Complete monitoring system with SSL dashboard
@@ -273,7 +275,7 @@ Matrix0 has achieved **SSL architecture integration** with a sophisticated 53M p
 ## Next Steps
 
 ### Immediate Actions (Completed - August 27, 2025)
-1. ✅ **SSL Integration Complete**: All 7 SSL algorithms fully integrated
+1. ✅ **SSL Integration Complete**: Five production SSL algorithms (piece, threat, pin, fork, control) fully integrated; pawn structure and king safety remain staged for future activation
 2. ✅ **WebUI Enhancement Complete**: Comprehensive monitoring system operational
 3. ✅ **Training Stability Resolved**: All scheduler/gradient issues fixed
 4. ✅ **Documentation Update**: Current status summary completely updated
@@ -314,7 +316,7 @@ Matrix0 has achieved **COMPLETE SSL INTEGRATION** with a sophisticated 53M param
 - 🎯 **WebUI Refinement**: Enhance SSL visualization and monitoring features
 
 ### Success Criteria (All Met)
-- ✅ **SSL Integration**: All 7 SSL algorithms working with training pipeline
+- ✅ **SSL Integration**: Five production SSL algorithms working with the training pipeline; experimental pawn structure and king safety heads are tracked separately
 - ✅ **Training Stability**: 100% stable training with full SSL capabilities
 - ✅ **Performance**: Optimized training throughput with SSL processing
 - ✅ **Documentation**: All technical docs updated and comprehensive

--- a/docs/PRETRAIN_EXTERNAL.md
+++ b/docs/PRETRAIN_EXTERNAL.md
@@ -7,8 +7,9 @@ The `pretrain_external.py` tool is designed for large-scale pretraining runs usi
 ## Features
 
 ### SSL Architecture Integration
-- **7 SSL Tasks**: piece, threat, pin, fork, control, pawn_structure, king_safety
-- **Individual Task Weights**: Configurable weights for each SSL task
+- **Production SSL Tasks**: piece, threat, pin, fork, control (enabled in config.yaml)
+- **Experimental SSL Tasks**: pawn_structure, king_safety (implemented but disabled by default)
+- **Individual Task Weights**: Configurable weights for each active SSL task
 - **SSL Warmup**: Gradual SSL weight increase over first 500 steps
 - **Enhanced SSL Loss**: Multi-task SSL learning with proper loss computation
 
@@ -90,8 +91,10 @@ python -m azchess.tools.pretrain_external \
 - `--ssl-pin-weight 0.7`: Pin detection task weight
 - `--ssl-fork-weight 0.6`: Fork detection task weight
 - `--ssl-control-weight 0.5`: Square control task weight
-- `--ssl-pawn-structure-weight 0.4`: Pawn structure task weight
-- `--ssl-king-safety-weight 0.4`: King safety task weight
+
+#### Experimental SSL (optional)
+- `--ssl-pawn-structure-weight 0.4`: Pawn structure task weight (requires enabling experimental head)
+- `--ssl-king-safety-weight 0.4`: King safety task weight (requires enabling experimental head)
 
 #### Training Configuration
 - `--steps 100000`: Total training steps
@@ -181,7 +184,7 @@ Every 5 minutes, the system logs:
 
 ### With Main Training Pipeline
 - **Checkpoint Compatibility**: Seamless integration with enhanced_best.pt
-- **SSL Architecture**: Full compatibility with 7-task SSL system
+- **SSL Architecture**: Full compatibility with the production 5-task SSL system (experimental pawn structure and king safety heads supported but disabled by default)
 - **Model Format**: Standard checkpoint format for orchestrator integration
 
 ### Evaluation

--- a/docs/model_v2.md
+++ b/docs/model_v2.md
@@ -6,7 +6,7 @@ Last updated: 2025-08-25
 
 ## 1) Current Production Architecture
 
-Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipeline and SSL foundation. The architecture is optimized for Apple Silicon MPS with advanced stability features and SSL foundation with integrated advanced algorithms.
+Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipeline and production SSL coverage. The architecture is optimized for Apple Silicon MPS with advanced stability features and five active SSL heads, while two additional experimental heads remain staged for future validation.
 
 ### Key Specifications
 - **Total Parameters**: 53,217,919 (53M)
@@ -14,14 +14,14 @@ Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipe
 - **Input**: 19×8×8 chess board representation
 - **Policy Output**: 4,672 move logits (from-square × to-square)
 - **Value Output**: Scalar win probability
-- **SSL Output**: 13-class per-square predictions (basic piece recognition working)
-- **Training Status**: Training pipeline operational with SSL foundation
+- **SSL Output**: Multi-head per-square predictions covering piece, threat, pin, fork, and control detection (production set of 5 tasks)
+- **Training Status**: Training pipeline operational with 5-task SSL integration
 
 ### Production Achievements
 - **Training Stability**: No NaN/Inf crashes with branch normalization
 - **Memory Efficiency**: 14GB MPS limit with automatic management
 - **Performance**: ~3-4s per training step on Apple Silicon
-- **SSL Foundation**: Basic piece recognition working, advanced algorithms integrated
+- **SSL Coverage**: Five production SSL tasks (piece, threat, pin, fork, control) active; pawn structure and king safety heads implemented but disabled pending data validation
 - **Data Pipeline**: Complete self-play → training → evaluation cycle
 
 ## 2) Implemented Architecture Features
@@ -43,10 +43,10 @@ Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipe
 - **Stability**: Gradient clipping and NaN/Inf detection
 
 ### SSL Implementation (Complete Integration)
-- **SSL Integration**: All 7 SSL tasks fully operational
-- **SSL Algorithms**: Advanced algorithms implemented and integrated
-- **SSL Architecture**: Dedicated multi-head SSL architecture with 7 task heads
-- **Current Status**: Complete SSL integration with multi-task learning
+- **SSL Integration**: Five production SSL tasks (piece, threat, pin, fork, control) fully operational
+- **SSL Algorithms**: Advanced algorithms implemented and integrated; pawn structure and king safety heads staged behind configuration flags
+- **SSL Architecture**: Dedicated multi-head SSL architecture with capacity for seven task heads
+- **Current Status**: Production SSL integration active with optional heads disabled by default
 - **Training Stability**: SSL integration working with stable training
 
 ### Training Stability Features
@@ -81,11 +81,11 @@ Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipe
 - **Parameters**: ~2M in attention components
 
 ### SSL Architecture (Foundation Ready)
-- **SSL Heads**: Dedicated multi-head SSL architecture (piece, threat, pin, fork, control, pawn_structure, king_safety)
-- **SSL Foundation**: Basic piece recognition working and operational
-- **SSL Algorithms**: Advanced algorithms implemented and integrated
-- **Current Status**: Full SSL integration and multi-task learning operational
-- **Parameters**: ~2M+ in SSL heads (distributed across tasks)
+- **SSL Heads**: Dedicated multi-head SSL architecture with five production heads (piece, threat, pin, fork, control) and two experimental heads (pawn_structure, king_safety) disabled by default
+- **SSL Coverage**: Production heads trained every step with curriculum-aware weighting
+- **SSL Algorithms**: Advanced algorithms implemented for all heads; experimental heads require additional data validation
+- **Current Status**: Full SSL integration for production tasks with optional head activation gated by configuration
+- **Parameters**: ~2M+ in SSL heads (distributed across active and optional tasks)
 
 ### Policy Head (Dual Branch Design)
 - **Input Features**: 320 channels from trunk
@@ -102,11 +102,11 @@ Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipe
 - **Parameters**: ~200K
 
 ### SSL Head (Complete Integration)
-- **Architecture**: Dedicated SSL heads for each task
-- **SSL Integration**: All 7 SSL tasks fully operational
-- **Current Status**: Complete SSL integration with multi-task learning
-- **Training**: All SSL tasks training simultaneously
-- **Parameters**: Dedicated SSL parameters
+- **Architecture**: Dedicated SSL heads for each task slot
+- **SSL Integration**: Five production SSL tasks (piece, threat, pin, fork, control) fully operational; pawn structure and king safety heads available but disabled
+- **Current Status**: Production SSL integration with multi-task learning across active heads
+- **Training**: Production SSL tasks training simultaneously each step; experimental tasks pending activation
+- **Parameters**: Dedicated SSL parameters for active heads with reserved capacity for experimental ones
 
 ### Outputs (Production Interface)
 - **Policy**: (B, 4672) - move logits (from-square × to-square)
@@ -120,7 +120,7 @@ Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipe
 - **Precision**: FP16 mixed precision
 - **Gradient Clipping**: 0.5 norm threshold
 - **SSL Weight**: 0.05 in total loss
-- **SSL Status**: Basic piece recognition working, advanced algorithms ready
+- **SSL Status**: Five production SSL tasks active; pawn structure and king safety heads available but disabled
 
 ## 4) Parameter Budget and Efficiency
 
@@ -134,7 +134,7 @@ Matrix0 V2 is a **53M parameter ResNet-24** model with operational training pipe
 
 ### Production Efficiency
 - **Policy Head**: Dual branch design with factorization saves parameters
-- **SSL Foundation**: Basic piece recognition working, advanced algorithms ready
+- **SSL Coverage**: Five production SSL tasks active with stable loss integration; experimental heads staged
 - **Memory Optimized**: 14GB MPS limit enables full training
 - **Training Stable**: No NaN/Inf issues with current safeguards
 
@@ -174,7 +174,7 @@ model:
   cross_modal_attention: true     # enable cross-modal attention
   
   # Enhanced SSL/SSRL
-  ssl_tasks: ["piece", "threat", "pin", "fork", "control", "pawn_structure", "king_safety"]  # All 7 SSL tasks enabled
+  ssl_tasks: ["piece", "threat", "pin", "fork", "control"]  # Production SSL tasks (experimental: pawn_structure, king_safety)
   ssl_curriculum: true            # enable progressive difficulty
   ssrl_tasks: ["masked_prediction", "contrastive", "rotation_invariance"]
   
@@ -284,13 +284,13 @@ llm_tutor:
 
 ### Enhanced SSL/SSRL System
 **Multi-Task SSL Tasks:**
-- **Piece Recognition**: Basic piece identification (✅ WORKING)
-- **Threat Detection**: Identify pieces under attack/defense (✅ IMPLEMENTED)
-- **Pin Detection**: Identify pinned pieces and constraints (✅ IMPLEMENTED)
-- **Fork Detection**: Identify forking opportunities and threats (✅ IMPLEMENTED)
-- **Control Detection**: Analyze square control and influence (✅ IMPLEMENTED)
-- **Pawn Structure**: Pawn chains, isolated pawns, passed pawns (✅ IMPLEMENTED)
-- **King Safety**: Recognize safe vs exposed king positions (✅ IMPLEMENTED)
+- **Piece Recognition**: Basic piece identification (✅ PRODUCTION)
+- **Threat Detection**: Identify pieces under attack/defense (✅ PRODUCTION)
+- **Pin Detection**: Identify pinned pieces and constraints (✅ PRODUCTION)
+- **Fork Detection**: Identify forking opportunities and threats (✅ PRODUCTION)
+- **Control Detection**: Analyze square control and influence (✅ PRODUCTION)
+- **Pawn Structure**: Pawn chains, isolated pawns, passed pawns (🧪 EXPERIMENTAL — disabled pending data validation)
+- **King Safety**: Recognize safe vs exposed king positions (🧪 EXPERIMENTAL — disabled pending data validation)
 
 **SSRL Learning Objectives:**
 - **Masked Position Prediction**: Hide random pieces, predict what should be there
@@ -299,11 +299,11 @@ llm_tutor:
 - **Temporal Consistency**: Adjacent moves should have similar representations
 
 **SSL Curriculum Progression:**
-1. **Level 1**: Basic piece recognition and board state (✅ WORKING)
-2. **Level 2**: Threat detection and piece relationships (✅ WORKING)
-3. **Level 3**: Pin detection and fork opportunities (✅ WORKING)
-4. **Level 4**: Control analysis and pawn structure (✅ WORKING)
-5. **Level 5**: King safety and complex tactical patterns (✅ WORKING)
+1. **Level 1**: Basic piece recognition and board state (✅ PRODUCTION)
+2. **Level 2**: Threat detection and piece relationships (✅ PRODUCTION)
+3. **Level 3**: Pin detection and fork opportunities (✅ PRODUCTION)
+4. **Level 4**: Control analysis and pawn structure (🧪 EXPERIMENTAL — staging pending data)
+5. **Level 5**: King safety and complex tactical patterns (🧪 EXPERIMENTAL — staging pending data)
 6. **Level 6**: Strategic concepts and long-term planning (✅ READY)
 7. **Level 7**: Advanced positional understanding (✅ READY)
 
@@ -393,7 +393,7 @@ model:
   policy_factor_rank: 0
   enable_visual: false
   enable_llm_tutor: false
-  ssl_tasks: ["piece", "threat", "pin", "fork", "control", "pawn_structure", "king_safety"]  # All 7 SSL tasks enabled
+  ssl_tasks: ["piece", "threat", "pin", "fork", "control"]  # Production SSL tasks (experimental: pawn_structure, king_safety)
 ```
 
 ### Gradual Fallback Options
@@ -440,7 +440,7 @@ model:
 ### Enhanced SSL/SSRL
 - [x] Basic SSL task implementation (piece recognition)
 - [x] Advanced SSL algorithms implemented in ssl_algorithms.py
-- [x] SSL task integration with training pipeline (all 7 tasks)
+- [x] SSL task integration with training pipeline (5 production tasks; experimental heads staged)
 - [x] SSL curriculum progression system
 - [x] Multi-task loss weighting and combination
 - [x] SSL validation and testing framework
@@ -492,7 +492,7 @@ model:
   aux_policy_move_type: true
   enable_visual: true
   enable_llm_tutor: true
-  ssl_tasks: ["piece", "threat", "pin", "fork", "control", "pawn_structure", "king_safety"]  # All 7 SSL tasks enabled
+  ssl_tasks: ["piece", "threat", "pin", "fork", "control"]  # Production SSL tasks (experimental: pawn_structure, king_safety)
   ssl_curriculum: true
   ssrl_tasks: ["masked_prediction", "contrastive", "rotation_invariance"]
 
@@ -537,5 +537,5 @@ llm_tutor:
 
 ---
 
-This enhanced V2 design represents a significant evolution of Matrix0, combining architectural improvements with SSL foundation ready for enhancement. The phased implementation approach ensures stability while enabling cutting-edge features like LLM-guided training and multi-modal learning. All features are configurable and can be enabled/disabled independently, providing maximum flexibility and risk mitigation.
+This enhanced V2 design represents a significant evolution of Matrix0, combining architectural improvements with production SSL coverage and a clear path for optional head expansion. The phased implementation approach ensures stability while enabling cutting-edge features like LLM-guided training and multi-modal learning. All features are configurable and can be enabled/disabled independently, providing maximum flexibility and risk mitigation.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,13 +61,13 @@ Matrix0 has achieved **production training capability** with a sophisticated 53M
 - [x] **Training pipeline operational** with stable performance
 - [x] **No NaN/Inf crashes** after branch normalization fixes
 - [x] **Memory optimization** to 14GB MPS limit
-- [x] **SSL foundation established** with complete 7-SSL-head integration
+- [x] **SSL foundation established** with five production SSL heads active and experimental pawn structure/king safety heads staged for future validation
 - [x] **Emergency checkpoints** working correctly
 
 ### Benchmark System Achievements (August 2025)
 - [x] **Advanced benchmark system** with multi-engine tournament support
 - [x] **LC0 integration** with Apple Silicon Metal backend optimization
-- [x] **SSL performance tracking** for all 7 SSL heads
+- [x] **SSL performance tracking** for all 5 production SSL heads (experimental pawn structure and king safety instrumentation hidden until activation)
 - [x] **Automated engine discovery** and intelligent configuration
 - [x] **Apple Silicon MPS monitoring** and performance analysis
 - [x] **Comprehensive tournament analysis** with ELO calculations

--- a/docs/status.md
+++ b/docs/status.md
@@ -3,14 +3,14 @@
 ## Executive Summary
 
 **Date**: September 2025
-**Status**: 🚀 SSL INTEGRATION COMPLETE - Advanced SSL Architecture with 7-Task Multi-Task Learning Framework Operational
+**Status**: 🚀 SSL INTEGRATION COMPLETE - Production 5-task SSL multi-head operational; experimental pawn structure & king safety heads staged for future validation
 **Priority**: HIGH - SSL Performance Validation and Enhanced Evaluation System
 
 ## Current Development Priorities
 
 ### 1. SSL Performance Validation 🎯
    - **Priority**: High
-   - **Benefit**: Measures and validates SSL learning effectiveness across all 7 tasks
+   - **Benefit**: Measures and validates SSL learning effectiveness across all 5 production tasks
    - **Corresponding files/modules**: `webui/server.py`, `azchess/ssl_algorithms.py`
    - **Status**: Ready for implementation
 
@@ -54,7 +54,7 @@
 
 ### 🔥 SSL Architecture Integration ✅ **ACHIEVED**
    - **Priority**: Critical
-   - **Benefit**: SSL architecture with 7 tasks (piece, threat, pin, fork, control, pawn_structure, king_safety) fully integrated
+   - **Benefit**: SSL architecture with five production tasks (piece, threat, pin, fork, control) fully integrated; pawn structure and king safety heads remain experimental and disabled in production runs
    - **Corresponding files/modules**: `azchess/ssl_algorithms.py`, `azchess/training/train.py`, `azchess/model/resnet.py`
    - **Status**: ✅ **ARCHITECTURE READY** - SSL framework operational, performance validation in progress
 
@@ -94,8 +94,8 @@
 
 #### 2. Complete SSL Architecture
 - **Model Size**: 53,206,724 parameters (53.2M) with SSL heads
-- **SSL Heads**: 7 specialized SSL heads (threat, pin, fork, control, piece, pawn_structure, king_safety detection)
-- **SSL Parameters**: 260,320 dedicated SSL parameters with weighted loss functions
+- **SSL Heads**: 5 production SSL heads (piece, threat, pin, fork, control) active; pawn structure and king safety heads implemented but disabled pending validation
+- **SSL Parameters**: Dedicated parameters for active heads with weighted loss functions; additional capacity reserved for experimental heads
 - **Multi-Task Learning**: Perfect integration of SSL with policy/value learning
 
 #### 3. Apple Silicon Optimization
@@ -203,7 +203,7 @@
 - **SSL Target Creation**: 0.17 seconds (optimized)
 - **Memory Efficiency**: Stable ~10.7-11.0GB usage with 18GB system memory and dtype consistency
 - **Numerical Stability**: Enhanced error handling, MPS type safety, and gradient clipping active
-- **SSL Status**: **FOUNDATION READY** - Basic piece recognition working, advanced algorithms integrated
+- **SSL Status**: **PRODUCTION ACTIVE** - Five SSL tasks (piece, threat, pin, fork, control) training; pawn structure and king safety remain experimental
 - **Model Quality**: Complete 474-key checkpoints with all architectural features intact
 
 ### 🎯 Enhancement Targets
@@ -220,7 +220,7 @@
 3. **Data Loss**: Comprehensive backup and recovery systems ✅
 4. **Memory Issues**: 14GB MPS limit with automatic management ✅
 5. **Numerical Stability**: Branch normalization preventing NaN/Inf ✅
-6. **SSL Foundation**: Basic piece recognition working, advanced algorithms implemented ✅
+6. **SSL Heads**: Five production SSL tasks (piece, threat, pin, fork, control) validated and active; experimental heads gated behind future validation ✅
 7. **MPS Type Safety**: Fixed autocast compatibility with dtype consistency ✅
 8. **Training Speed**: Optimized training steps with enhanced memory management ✅
 9. **Checkpoint Integrity**: Complete 474-key model checkpoints ✅
@@ -254,27 +254,27 @@
 
 ## Conclusion
 
-Matrix0 has achieved **major training milestones** with a 53M parameter model and operational training pipeline. The system demonstrates robust performance with SSL foundation established:
+Matrix0 has achieved **major training milestones** with a 53M parameter model and operational training pipeline. The system demonstrates robust performance with five production SSL heads active and experimental extensions staged:
 
 ### ✅ Production-Ready Features
 - **Complete Training Pipeline**: Self-play → Training → Evaluation → Model Promotion
-- **Advanced Architecture**: ResNet-24 with attention and SSL foundation
+- **Advanced Architecture**: ResNet-24 with attention and five production SSL heads
 - **Training Stability**: No NaN/Inf crashes with emergency recovery
 - **Apple Silicon Optimization**: Optimized MPS memory management
 - **Data Integrity**: SQLite metadata with automatic backup
 - **Model Evaluation**: Basic evaluation system operational
 
 ### ✅ All Critical Issues RESOLVED
-- **SSL Foundation**: Basic piece recognition working, advanced algorithms integrated
+- **SSL Heads**: Five production tasks (piece, threat, pin, fork, control) operational; pawn structure and king safety heads implemented but disabled pending validation
 - **Checkpoint Creation**: Fixed create_v2_checkpoint.py creates complete 474-key checkpoints
 - **Missing Keys**: Completely resolved - all model parameters properly saved/loaded
 - **Multiprocessing**: Fixed event compatibility issues for stable communication
 - **Training Parameters**: Resolved precision parameter definition issues
 - **Memory Management**: Enhanced with automatic cache clearing, dtype consistency, and OOM protection
-- **Impact**: Complete training system now operational with SSL foundation ready for enhancement
+- **Impact**: Complete training system now operational with production SSL coverage and a clear path for optional head expansion
 
 ### 🔄 Active Development Priorities
-1. **SSL Completion**: Enable all implemented SSL algorithms for full multi-task learning
+1. **Experimental SSL Activation**: Prepare data and validation metrics for pawn structure and king safety heads before enabling them
 2. **Data Integration**: Leverage 356K+ external samples for enhanced training
 3. **Performance Optimization**: Memory usage and training throughput with expanded dataset
 4. **Training Enhancement**: Achieve stable training with full SSL capabilities
@@ -282,7 +282,7 @@ Matrix0 has achieved **major training milestones** with a 53M parameter model an
 ### 📊 Current Status
 **Matrix0 has achieved complete system stability with all critical issues resolved and SSL foundation established!** The training system is now fully operational with:
 
-- ✅ **SSL Foundation**: Basic piece recognition working, advanced algorithms implemented
+- ✅ **SSL Coverage**: Five production tasks (piece, threat, pin, fork, control) fully integrated and training; optional pawn structure and king safety heads staged
 - ✅ **Training Pipeline**: Complete self-play → training → evaluation cycle operational
 - ✅ **Model Architecture**: 53M parameter ResNet-24 with all features intact
 - ✅ **Memory Management**: 14GB MPS limit with automatic cleanup and optimization
@@ -296,5 +296,5 @@ Matrix0 has achieved **major training milestones** with a 53M parameter model an
 
 ---
 
-**Status**: Training pipeline operational with SSL foundation - validating advanced SSL algorithm effectiveness
+**Status**: Training pipeline operational with five production SSL tasks - validating learning quality and planning experimental head rollout
 **Next Review**: After validating SSL algorithm effectiveness and optimizing multi-task learning

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -89,8 +89,9 @@ Tip: The Orchestrator tab also tails `logs/structured.jsonl` for general logs an
   "stockfish": true,
   "model_params": 53206724,
   "device": "cpu",
-      "ssl_enabled": true,
-    "ssl_tasks": ["piece", "threat", "pin", "fork", "control", "pawn_structure", "king_safety"],
+    "ssl_enabled": true,
+    "ssl_tasks": ["piece", "threat", "pin", "fork", "control"],
+    "experimental_ssl_tasks": ["pawn_structure", "king_safety"],
     "training_status": "operational"
 }
 ```
@@ -101,8 +102,9 @@ Tip: The Orchestrator tab also tails `logs/structured.jsonl` for general logs an
 ```json
 {
       "enabled": true,
-    "tasks": ["piece", "threat", "pin", "fork", "control", "pawn_structure", "king_safety"],
-    "ssl_head_count": 7,
+    "tasks": ["piece", "threat", "pin", "fork", "control"],
+    "experimental_tasks": ["pawn_structure", "king_safety"],
+    "ssl_head_count": 5,
     "total_ssl_params": "dedicated",
     "head_parameters": {
       "piece": "dedicated",
@@ -110,8 +112,8 @@ Tip: The Orchestrator tab also tails `logs/structured.jsonl` for general logs an
       "pin": "dedicated",
       "fork": "dedicated",
       "control": "dedicated",
-      "pawn_structure": "dedicated",
-      "king_safety": "dedicated"
+      "pawn_structure": "dedicated (disabled)",
+      "king_safety": "dedicated (disabled)"
     }
 }
 ```
@@ -154,15 +156,16 @@ Tip: The Orchestrator tab also tails `logs/structured.jsonl` for general logs an
       "pin": {"parameters": "dedicated", "structure": "..."},
       "fork": {"parameters": "dedicated", "structure": "..."},
       "control": {"parameters": "dedicated", "structure": "..."},
-      "pawn_structure": {"parameters": "dedicated", "structure": "..."},
-      "king_safety": {"parameters": "dedicated", "structure": "..."}
+      "pawn_structure": {"parameters": "dedicated", "structure": "...", "status": "experimental"},
+      "king_safety": {"parameters": "dedicated", "structure": "...", "status": "experimental"}
     },
     "architecture": {
       "channels": 320,
       "blocks": 24,
       "attention_heads": 20,
       "ssl_enabled": true,
-      "ssl_tasks": ["piece", "threat", "pin", "fork", "control", "pawn_structure", "king_safety"]
+      "ssl_tasks": ["piece", "threat", "pin", "fork", "control"],
+      "experimental_ssl_tasks": ["pawn_structure", "king_safety"]
     }
 }
 ```
@@ -268,14 +271,14 @@ The enhanced WebUI features four specialized views accessible via the top naviga
 
 #### 🔬 SSL View - Advanced SSL Monitoring
 1. **SSL Configuration**: View current SSL settings and task status
-2. **SSL Heads Analysis**: Examine all 7 SSL heads:
-   - **Piece Detection**: Dedicated SSL parameters
-   - **Threat Detection**: Dedicated SSL parameters
-   - **Pin Detection**: Dedicated SSL parameters
-   - **Fork Detection**: Dedicated SSL parameters
-   - **Control Detection**: Dedicated SSL parameters
-   - **Pawn Structure**: Dedicated SSL parameters
-   - **King Safety**: Dedicated SSL parameters
+2. **SSL Heads Analysis**: Examine all 5 production SSL heads, with experimental heads called out separately:
+   - **Piece Detection**: Dedicated SSL parameters (production)
+   - **Threat Detection**: Dedicated SSL parameters (production)
+   - **Pin Detection**: Dedicated SSL parameters (production)
+   - **Fork Detection**: Dedicated SSL parameters (production)
+   - **Control Detection**: Dedicated SSL parameters (production)
+   - **Pawn Structure**: Dedicated SSL parameters (experimental, disabled by default)
+   - **King Safety**: Dedicated SSL parameters (experimental, disabled by default)
 3. **Parameter Tracking**: Monitor SSL learning effectiveness
 4. **SSL Performance**: Track task balancing and contribution
 
@@ -403,15 +406,15 @@ For complete API documentation, visit `http://127.0.0.1:8000/docs` when the serv
 ## Current Project Status
 
 ### Training Pipeline
-- **Status**: ✅ **FULLY OPERATIONAL** with complete SSL integration
-- **SSL Integration**: ✅ **COMPLETE** - All 7 SSL tasks working simultaneously
+- **Status**: ✅ **FULLY OPERATIONAL** with production 5-task SSL integration
+- **SSL Integration**: ✅ **COMPLETE** - Five SSL tasks (piece, threat, pin, fork, control) training simultaneously; pawn structure and king safety heads remain experimental and disabled
 - **Multi-Task Learning**: ✅ **ACTIVE** - Policy, value, and SSL training combined
 - **Real-time Monitoring**: ✅ **ENHANCED** - WebUI provides comprehensive monitoring
 
 ### Model Architecture
 - **Parameters**: 53M+ (ResNet-24 with complete SSL integration)
-- **SSL Heads**: **7 specialized SSL heads** (piece, threat, pin, fork, control, pawn_structure, king_safety)
-- **SSL Parameters**: Dedicated SSL parameters with weighted loss functions
+- **SSL Heads**: **5 production SSL heads** (piece, threat, pin, fork, control) active; pawn_structure and king_safety heads implemented but disabled by default
+- **SSL Parameters**: Dedicated SSL parameters with weighted loss functions for production heads and reserved capacity for experimental ones
 - **Memory Usage**: 14GB MPS limit with SSL processing optimization
 - **Performance**: ~3-4 seconds per training step with SSL
 


### PR DESCRIPTION
## Summary
- clarify in the current status summary that five SSL heads are in production and pawn structure / king safety remain experimental
- align status, roadmap, model, pretraining, and web UI docs so they reference the same production task set and explicitly mark experimental heads
- update API examples and configuration snippets to list the five active tasks while flagging optional experimental heads separately

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d1b3f088c48323bfd2061aa4fef0d3