### PR TITLE
Align self-play worker defaults across docs and experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Matrix0 implements **cutting-edge multi-task learning** combining reinforcement 
 - **Modern UI**: Clean, professional interface with efficient space utilization
 
 ### Production Training Pipeline
-- **Self-Play Generation**: 4 workers generating SSL-enhanced training data
+- **Self-Play Generation**: 3 workers by default (configurable) generating SSL-enhanced training data
 - **Multi-Task Training**: Combined policy/value/SSL optimization with proper gradient accumulation
 - **Model Evaluation**: Tournament system with SSL-aware strength estimation
 - **Checkpoint Management**: Advanced checkpoint creation preserving SSL architecture

--- a/config.yaml
+++ b/config.yaml
@@ -22,7 +22,7 @@ model:
   ssrl_tasks: []                   # Keep SSRL off for now (optional)
 
 selfplay:
-  num_workers: 3                   # Next pass: 3 workers
+  num_workers: 3                   # Default worker count
   batch_size: 256                  # Increased from 128 for better efficiency
   max_games: 420                    # TEST RUN: 20 games total
   max_game_len: 180                # Encourage decisive results
@@ -158,7 +158,7 @@ mcts:
 presets:
   mps:
     device: "mps"
-    num_threads: 4  # Match worker count
+    num_threads: 3  # Match default worker count
     inference_batch_size: 32
-    mcts_threads: 4  # Match worker count
-    worker_threads: 1  # 1 core per worker for 4 workers
+    mcts_threads: 3  # Match default worker count
+    worker_threads: 1  # 1 core per worker (3 workers)

--- a/docs/status.md
+++ b/docs/status.md
@@ -87,7 +87,7 @@
 ### ✅ Production-Ready Components
 
 #### 1. Complete SSL Training Pipeline
-- **Self-Play Generation**: 4 workers generating SSL-enhanced training data
+- **Self-Play Generation**: 3 workers by default (configurable) generating SSL-enhanced training data
 - **Multi-Task Training**: Simultaneous policy, value, and SSL optimization
 - **Model Evaluation**: Tournament system with SSL-aware strength estimation
 - **Checkpoint Management**: Advanced SSL-preserving checkpoint creation and merging

--- a/experiments/grpo/mcts/mcts_integration.py
+++ b/experiments/grpo/mcts/mcts_integration.py
@@ -743,14 +743,14 @@ class MCTS:
 class SelfPlayManager:
     """Manages self-play games for GRPO training"""
 
-    def __init__(self, mcts_factory: Callable[[], MCTS], num_workers: int = 4, display_callback=None):
+    def __init__(self, mcts_factory: Callable[[], MCTS], num_workers: int = 3, display_callback=None):
         """Create a self-play manager.
 
         Args:
             mcts_factory: Callable that returns a new :class:`MCTS` instance.
                 A separate MCTS will be created for each worker to avoid
                 shared mutable state across threads.
-            num_workers: Number of parallel workers.
+            num_workers: Number of parallel workers (default: 3).
             display_callback: Optional callback for displaying trajectories.
         """
 

--- a/experiments/grpo/scripts/grpo_orchestrator.py
+++ b/experiments/grpo/scripts/grpo_orchestrator.py
@@ -244,7 +244,7 @@ class GRPOOrchestrator:
         
         self.self_play_manager = SelfPlayManager(
             mcts_factory,
-            num_workers=grpo_config.get('num_workers', 4),  # Default to 4 workers
+            num_workers=grpo_config.get('num_workers', 3),  # Default to 3 workers
             display_callback=display_callback
         )
 


### PR DESCRIPTION
## Summary
- update README and status documentation to note the three-worker self-play baseline and configurability
- adjust configuration presets and comments to reflect three default self-play workers
- update GRPO experimental defaults so SelfPlayManager and the orchestrator fall back to three workers instead of four

## Testing
- PYTHONPATH=experiments/grpo pytest tests/test_selfplay_manager.py *(fails: RuntimeError: Boolean value of Tensor with more than one value is ambiguous)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bc534a7083239dd1439e719c5b53