### PR TITLE
Fix memory alert message formatting

### DIFF
--- a/azchess/utils/memory_monitor.py
+++ b/azchess/utils/memory_monitor.py
@@ -117,11 +117,16 @@ class MemoryMonitor:
             self.memory_history.append(memory_usage_gb)
             self.history_timestamps.append(current_time)
 
-            # Calculate memory ratio
+            # Calculate memory ratio and human-readable usage string
             if memory_limit_gb > 0:
                 memory_ratio = memory_usage_gb / memory_limit_gb
+                usage_message = (
+                    f"memory {memory_usage_gb:.1f}/{memory_limit_gb:.1f} GB "
+                    f"({memory_ratio:.0%})"
+                )
             else:
                 memory_ratio = 0
+                usage_message = f"memory {memory_usage_gb:.1f} GB (limit unknown)"
 
             # Check for alerts
             alert = None
@@ -132,7 +137,7 @@ class MemoryMonitor:
                 if current_time - self.last_alert_time > self.alert_cooldown:
                     alert = MemoryAlert(
                         alert_type='critical',
-                        message=".1f",
+                        message=usage_message,
                         memory_usage_gb=memory_usage_gb,
                         memory_limit_gb=memory_limit_gb,
                         timestamp=current_time,
@@ -153,7 +158,7 @@ class MemoryMonitor:
                 if current_time - self.last_alert_time > self.alert_cooldown:
                     alert = MemoryAlert(
                         alert_type='warning',
-                        message=".1f",
+                        message=usage_message,
                         memory_usage_gb=memory_usage_gb,
                         memory_limit_gb=memory_limit_gb,
                         timestamp=current_time,

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -1,0 +1,44 @@
+import logging
+
+from azchess.utils import memory_monitor as memory_monitor_module
+from azchess.utils.memory_monitor import MemoryMonitor
+
+
+def test_memory_alert_messages_include_usage(monkeypatch, caplog):
+    monitor = MemoryMonitor(warning_threshold=0.5, critical_threshold=0.8, alert_cooldown=0)
+    device = "cuda"
+    monitor.device_limits[device] = 10.0
+
+    monkeypatch.setattr(memory_monitor_module, "get_memory_usage", lambda d: {"memory_gb": 9.0})
+    monkeypatch.setattr(memory_monitor_module, "emergency_memory_cleanup", lambda d: None)
+    monkeypatch.setattr(memory_monitor_module, "clear_memory_cache", lambda d: None)
+
+    recorded_alerts = []
+    monitor.alert_callbacks.append(recorded_alerts.append)
+
+    with caplog.at_level(logging.CRITICAL):
+        monitor._check_memory_and_alert(device)
+
+    assert recorded_alerts, "Expected a critical alert to be recorded"
+    critical_alert = recorded_alerts[-1]
+    assert critical_alert.alert_type == "critical"
+    assert critical_alert.message == "memory 9.0/10.0 GB (90%)"
+    assert any(
+        message == "MEMORY_ALERT: memory 9.0/10.0 GB (90%)"
+        for message in caplog.messages
+    ), "Critical MEMORY_ALERT log should include usage details"
+
+    caplog.clear()
+    monkeypatch.setattr(memory_monitor_module, "get_memory_usage", lambda d: {"memory_gb": 7.0})
+    monitor.last_alert_time -= 1  # allow another alert immediately
+
+    with caplog.at_level(logging.WARNING):
+        monitor._check_memory_and_alert(device)
+
+    warning_alert = recorded_alerts[-1]
+    assert warning_alert.alert_type == "warning"
+    assert warning_alert.message == "memory 7.0/10.0 GB (70%)"
+    assert any(
+        message == "MEMORY_ALERT: memory 7.0/10.0 GB (70%)"
+        for message in caplog.messages
+    ), "Warning MEMORY_ALERT log should include usage details"


### PR DESCRIPTION
## Summary
- build a single human-readable memory usage message before constructing alerts
- reuse the formatted message for both warning and critical alerts so logs include the numbers
- add unit coverage verifying the alert message and log contents

## Testing
- pytest tests/test_memory_monitor.py

------
https://chatgpt.com/codex/tasks/task_e_68d1c2a925248323987cc30c138d0835